### PR TITLE
Add User type

### DIFF
--- a/lib/spree/graphql/types/query.rb
+++ b/lib/spree/graphql/types/query.rb
@@ -28,6 +28,10 @@ module Spree
               null: false,
               description: 'Supported Taxonomies.'
 
+        field :current_user, Types::User,
+              null: true,
+              description: 'Current logged User.'
+
         def countries
           Spree::Queries::CountriesQuery.new.call
         end
@@ -42,6 +46,10 @@ module Spree
 
         def taxonomies
           Spree::Queries::TaxonomiesQuery.new.call
+        end
+
+        def current_user
+          context[:current_user]
         end
       end
     end

--- a/lib/spree/graphql/types/user.rb
+++ b/lib/spree/graphql/types/user.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    module Types
+      class User < Base::RelayNode
+        description 'User.'
+
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :current_sign_in_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :email, String, null: false
+        field :last_sign_in_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :login, String, null: true
+        field :sign_in_count, Integer, null: false
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -473,6 +473,11 @@ type Query {
   ): CountryConnection!
 
   """
+  Current logged User.
+  """
+  currentUser: User
+
+  """
   Fetches an object given its ID.
   """
   node(
@@ -732,6 +737,20 @@ type TaxonomyEdge {
   The item at the end of the edge.
   """
   node: Taxonomy
+}
+
+"""
+User.
+"""
+type User implements Node {
+  createdAt: ISO8601DateTime
+  currentSignInAt: ISO8601DateTime
+  email: String!
+  id: ID!
+  lastSignInAt: ISO8601DateTime
+  login: String
+  signInCount: Int!
+  updatedAt: ISO8601DateTime
 }
 
 """

--- a/spec/expected_schema.graphql
+++ b/spec/expected_schema.graphql
@@ -25,6 +25,11 @@ type Query {
   ): CountryConnection!
 
   """
+  Current logged User.
+  """
+  currentUser: User
+
+  """
   Fetches an object given its ID.
   """
   node(
@@ -437,6 +442,20 @@ type TaxonomyEdge {
   The item at the end of the edge.
   """
   node: Taxonomy
+}
+
+"""
+User.
+"""
+type User implements Node {
+  createdAt: ISO8601DateTime
+  currentSignInAt: ISO8601DateTime
+  email: String!
+  id: ID!
+  lastSignInAt: ISO8601DateTime
+  login: String
+  signInCount: Int!
+  updatedAt: ISO8601DateTime
 }
 
 """

--- a/spec/integration/current_user_spec.rb
+++ b/spec/integration/current_user_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "Current User" do
+  include_examples 'query is successful', :currentUser do
+    let(:user) { create(:user) }
+    let(:context) { Hash[current_user: user] }
+
+    it { expect(subject.data.currentUser).to_not be_nil }
+  end
+end

--- a/spec/queries/currentUser.gql
+++ b/spec/queries/currentUser.gql
@@ -1,0 +1,11 @@
+query {
+  currentUser {
+    email
+    signInCount
+    currentSignInAt
+    lastSignInAt
+    login
+    createdAt
+    updatedAt
+  }
+}

--- a/spec/support/helpers/graphql.rb
+++ b/spec/support/helpers/graphql.rb
@@ -2,9 +2,12 @@
 
 module Helpers
   module Graphql
-    def execute_query(query)
+    def execute_query(query, context:)
       JSON.parse(
-        Spree::Graphql::Schema.execute(File.read("spec/queries/#{query}.gql")).to_json,
+        Spree::Graphql::Schema.execute(
+          File.read("spec/queries/#{query}.gql"),
+          context: context
+        ).to_json,
         object_class: OpenStruct
       )
     end

--- a/spec/support/shared_examples/query_is_successful.rb
+++ b/spec/support/shared_examples/query_is_successful.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'query is successful' do |query|
-  subject { execute_query(query) }
+  subject { execute_query(query, context: context) }
+
+  let(:context) { nil }
 
   it { expect{ subject }.to_not raise_error }
 end


### PR DESCRIPTION
The `current_user` field returns the `context[:current_user]` in form of ` Types::User`.
If the user isn't logged in, the field returns nil.

For more information about how the `current_user` is initialized in the `context`, refer to:
[Spree::GraphqlController: current_user](https://github.com/nebulab/solidus_graphql_api-1/blob/d21afcc8a4f5447e3b1f03ff7dc57f75d2d949ba/app/controllers/spree/graphql_controller.rb#L47-L49)