### PR TITLE
Add Address type

### DIFF
--- a/lib/spree/graphql/types/address.rb
+++ b/lib/spree/graphql/types/address.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    module Types
+      class Address < Base::RelayNode
+        description 'Address.'
+
+        field :address1, String, null: true
+        field :address2, String, null: true
+        field :alternative_phone, String, null: true
+        field :city, String, null: true
+        field :company, String, null: true
+        field :country, Types::Country, null: true
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :firstname, String, null: true
+        field :lastname, String, null: true
+        field :phone, String, null: true
+        field :state_name, String, null: true
+        field :state, Types::State, null: true
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :zipcode, String, null: true
+
+        def state
+          Spree::Queries::Address::StateQuery.new(address: object).call
+        end
+
+        def country
+          Spree::Queries::Address::CountryQuery.new(address: object).call
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/queries/address/country_query.rb
+++ b/lib/spree/queries/address/country_query.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  module Queries
+    module Address
+      class CountryQuery
+        attr_reader :address
+
+        def initialize(address:)
+          @address = address
+        end
+
+        def call
+          BatchLoader::GraphQL.for(address.country_id).batch do |country_ids, loader|
+            Spree::Country.where(id: country_ids).each do |country|
+              loader.call(country.id, country)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/queries/address/state_query.rb
+++ b/lib/spree/queries/address/state_query.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  module Queries
+    module Address
+      class StateQuery
+        attr_reader :address
+
+        def initialize(address:)
+          @address = address
+        end
+
+        def call
+          BatchLoader::GraphQL.for(address.state_id).batch do |state_ids, loader|
+            Spree::State.where(id: state_ids).each do |state|
+              loader.call(state.id, state)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/spree/graphql/types/address_spec.rb
+++ b/spec/lib/spree/graphql/types/address_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Graphql::Types::Address do
+  let(:address) { create(:address) }
+  let(:query_object) { spy(:query_object) }
+
+  subject { described_class.send(:new, address, {}) }
+
+  describe '#country' do
+    before do
+      allow(Spree::Queries::Address::CountryQuery).to(
+        receive(:new).with(address: address).and_return(query_object)
+      )
+    end
+
+    after { subject.country }
+
+    it { expect(query_object).to receive(:call) }
+  end
+
+  describe '#state' do
+    before do
+      allow(Spree::Queries::Address::StateQuery).to(
+        receive(:new).with(address: address).and_return(query_object)
+      )
+    end
+
+    after { subject.state }
+
+    it { expect(query_object).to receive(:call) }
+  end
+end

--- a/spec/lib/spree/queries/address/country_query_spec.rb
+++ b/spec/lib/spree/queries/address/country_query_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Queries::Address::CountryQuery do
+  subject { described_class.new(address: address).call.sync }
+
+  let(:address) { create(:address) }
+
+  let(:country) { address.country }
+
+  it { is_expected.to eq(country) }
+end

--- a/spec/lib/spree/queries/address/state_query_spec.rb
+++ b/spec/lib/spree/queries/address/state_query_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Queries::Address::StateQuery do
+  subject { described_class.new(address: address).call.sync }
+
+  let(:address) { create(:address) }
+
+  let(:state) { address.state }
+
+  it { is_expected.to eq(state) }
+end


### PR DESCRIPTION
Add `AddressType`. It will be used in the [`UserType`](#12):
 - [x] Add primitive fields;
 - [x] Add `Spree::Queries::Address::Country` query object with a batch loader to retrieve the country of the address;
 - [x] Add `Spree::Queries::Address::State` query object with a batch loader to retrieve the state of the address;
 - [x] Add some query object specs to test the correct return of the batch loaders.