### PR TITLE
Batch loading framework

### DIFF
--- a/lib/spree/graphql/batch_loader.rb
+++ b/lib/spree/graphql/batch_loader.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    # Provides an abstraction layer on top of +BatchLoader::GraphQL+ that removes all the
+    # boilerplate normally needed to batch-load ActiveRecord associations.
+    #
+    # @example Batch-loading a user's posts
+    #   BatchLoader.for(user, :posts)
+    class BatchLoader
+      LOADER_CLASSES = {
+        has_one: Spree::Graphql::BatchLoader::HasOne,
+        has_many: Spree::Graphql::BatchLoader::HasMany,
+        has_many_through: Spree::Graphql::BatchLoader::HasManyThrough,
+        belongs_to: Spree::Graphql::BatchLoader::BelongsTo,
+      }.freeze
+
+      class << self
+        # Generates the batch loader for an ActiveRecord instance-association pair.
+        #
+        # @param object [ActiveRecord::Base] the record whose association you want to batch-load
+        # @param association [Symbol] the association to batch-load
+        # @param options [Hash] an options hash
+        #
+        # @option scope [ActiveRecord::Relation] a relation to use for scoping the association
+        #
+        # @return [BatchLoader::GraphQL]
+        #
+        # @see #new
+        def for(object, association, options = {})
+          reflection = object.class.reflect_on_association(association)
+          loader_class_for(reflection).new(object, reflection, options).load
+        end
+
+        private
+
+        def loader_class_for(reflection)
+          association_type = association_type(reflection)
+          LOADER_CLASSES[association_type] ||
+            raise(ArgumentError, "#{association_type} associations do not support batch loading")
+        end
+
+        def association_type(reflection)
+          macro = reflection.macro.to_sym
+
+          case macro
+          when :has_many
+            if reflection.through_reflection
+              :has_many_through
+            else
+              :has_many
+            end
+          else
+            macro
+          end
+        end
+      end
+
+      attr_reader :object, :reflection, :options
+
+      # Generates a new instance of this batch loader for an ActiveRecord instance-association pair.
+      #
+      # @param object [ActiveRecord::Base] the record whose association you want to batch-load
+      # @param reflection [ActiveRecord::Reflection] the association to batch-load
+      # @param options [Hash] an options hash
+      #
+      # @option scope [ActiveRecord::Relation] a relation to use for scoping the association
+      # @option klass [Class] the model class to load (only for polymorphic associations)
+      def initialize(object, reflection, options = {})
+        @object = object
+        @reflection = reflection
+        @options = options
+      end
+
+      # Returns the batch loading logic.
+      #
+      # @return [BatchLoader::GraphQL]
+      def load
+        raise NotImplementedError
+      end
+
+      private
+
+      def association_klass
+        if reflection.polymorphic?
+          options[:klass] || raise(
+            ArgumentError,
+            'You need to provide :klass when batch-loading a polymorphic association!',
+          )
+        else
+          reflection.klass
+        end
+      end
+
+      def base_relation
+        relation = association_klass
+        relation = relation.instance_eval(&reflection.scope) if reflection.scope
+        relation = relation.merge(options[:scope]) if options[:scope]
+        relation
+      end
+
+      def default_options
+        return @default_options if @default_options
+
+        key_components = [object.class, object.id, reflection.name, options.inspect]
+        key = Digest::MD5.hexdigest(key_components.join)
+
+        @default_options ||= { key: key }.freeze
+      end
+
+      def graphql_loader_for(object_id, options = {}, &block)
+        ::BatchLoader::GraphQL.for(object_id).batch(default_options.merge(options), &block)
+      end
+    end
+  end
+end

--- a/lib/spree/graphql/batch_loader/belongs_to.rb
+++ b/lib/spree/graphql/batch_loader/belongs_to.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    class BatchLoader
+      # A batch loader for +belongs_to+ associations.
+      class BelongsTo < BatchLoader
+        def load
+          graphql_loader_for(object.send(reflection.foreign_key)) do |object_ids, loader|
+            retrieve_records_for(object_ids).each do |record|
+              loader.call(record.send(association_primary_key), record)
+            end
+          end
+        end
+
+        private
+
+        def retrieve_records_for(object_ids)
+          base_relation.where(association_primary_key => object_ids)
+        end
+
+        def association_primary_key
+          if reflection.polymorphic?
+            association_klass.primary_key
+          else
+            reflection.association_primary_key
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/graphql/batch_loader/has_many.rb
+++ b/lib/spree/graphql/batch_loader/has_many.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    class BatchLoader
+      # A batch loader for +has_many+ associations.
+      class HasMany < BatchLoader
+        def load
+          graphql_loader_for(object.id, default_value: []) do |object_ids, loader|
+            retrieve_records_for(object_ids).each do |associated_record|
+              loader.call(associated_record.send(reflection.foreign_key)) do |memo|
+                memo << associated_record
+              end
+            end
+          end
+        end
+
+        private
+
+        def retrieve_records_for(object_ids)
+          base_relation.where(reflection.foreign_key => object_ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/graphql/batch_loader/has_many_through.rb
+++ b/lib/spree/graphql/batch_loader/has_many_through.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    class BatchLoader
+      # A batch loader for +has_many :through+ associations.
+      class HasManyThrough < BatchLoader
+        def load
+          graphql_loader_for(object.id, default_value: []) do |object_ids, loader|
+            records_by_parent = group_records_by_parent(retrieve_records_for(object_ids))
+
+            records_by_parent.each_pair do |parent_id, children|
+              loader.call(parent_id) do |memo|
+                memo.concat(children)
+              end
+            end
+          end
+        end
+
+        private
+
+        def retrieve_records_for(object_ids)
+          through_reflection = reflection.through_reflection
+
+          base_relation
+            .joins(through_reflection.name)
+            .where("#{through_reflection.table_name}.#{through_reflection.foreign_key}" => object_ids)
+        end
+
+        def group_records_by_parent(records)
+          result = Hash.new { |h, k| h[k] = [] }
+
+          records.each do |record|
+            record.send(reflection.through_reflection.name).each do |parent|
+              result[parent.send(reflection.through_reflection.foreign_key)] << record
+            end
+          end
+
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/graphql/batch_loader/has_one.rb
+++ b/lib/spree/graphql/batch_loader/has_one.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    class BatchLoader
+      # A batch loader for +has_one+ associations.
+      class HasOne < BatchLoader
+        def load
+          graphql_loader_for(object.id) do |object_ids, loader|
+            retrieve_records_for(object_ids).each do |record|
+              loader.call(record.send(reflection.foreign_key), record)
+            end
+          end
+        end
+
+        private
+
+        def retrieve_records_for(object_ids)
+          base_relation.where(reflection.foreign_key => object_ids)
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/graphql/schema.rb
+++ b/lib/spree/graphql/schema.rb
@@ -5,7 +5,7 @@ module Spree
     class Schema < GraphQL::Schema
       query Types::Query
 
-      use BatchLoader::GraphQL
+      use ::BatchLoader::GraphQL
 
       # Relay Object Identification:
       class << self

--- a/lib/spree/queries/address/country_query.rb
+++ b/lib/spree/queries/address/country_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(address.country_id).batch do |country_ids, loader|
-            Spree::Country.where(id: country_ids).each do |country|
-              loader.call(country.id, country)
-            end
-          end
+          Spree::Graphql::BatchLoader.for(address, :country)
         end
       end
     end

--- a/lib/spree/queries/address/state_query.rb
+++ b/lib/spree/queries/address/state_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(address.state_id).batch do |state_ids, loader|
-            Spree::State.where(id: state_ids).each do |state|
-              loader.call(state.id, state)
-            end
-          end
+          Spree::Graphql::BatchLoader.for(address, :state)
         end
       end
     end

--- a/lib/spree/queries/country/states_query.rb
+++ b/lib/spree/queries/country/states_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(country.id).batch(default_value: []) do |country_ids, loader|
-            Spree::State.where(country_id: country_ids).each do |state|
-              loader.call(state.country_id) { |memo| memo << state }
-            end
-          end
+          Spree::Graphql::BatchLoader.for(country, :states)
         end
       end
     end

--- a/lib/spree/queries/option_type/option_values_query.rb
+++ b/lib/spree/queries/option_type/option_values_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(option_type.id).batch(default_value: []) do |option_type_ids, loader|
-            Spree::OptionValue.where(option_type_id: option_type_ids).each do |option_value|
-              loader.call(option_value.option_type_id) { |memo| memo << option_value }
-            end
-          end
+          Spree::Graphql::BatchLoader.for(option_type, :option_values)
         end
       end
     end

--- a/lib/spree/queries/product/master_variant_query.rb
+++ b/lib/spree/queries/product/master_variant_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader.for(product.id).batch do |product_ids, loader|
-            Spree::Variant.where(is_master: true).where(product_id: product_ids).each do |variant|
-              loader.call(variant.product_id, variant)
-            end
-          end
+          Spree::Graphql::BatchLoader.for(product, :master)
         end
       end
     end

--- a/lib/spree/queries/product/option_types_query.rb
+++ b/lib/spree/queries/product/option_types_query.rb
@@ -11,21 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(product.id).batch(default_value: []) do |product_ids, loader|
-            option_types_by_variant_ids(product_ids).each do |product_id, option_types|
-              loader.call(product_id) { |memo| memo.concat(option_types) }
-            end
-          end
-        end
-
-        private
-
-        def option_types_by_variant_ids(product_ids)
-          result = Hash.new { |h, k| h[k] = [] }
-          Spree::OptionType.includes(:products).where("spree_product_option_types.product_id": product_ids).each do |option_type|
-            option_type.products.each { |product| result[product.id] << option_type }
-          end
-          result
+          Spree::Graphql::BatchLoader.for(product, :option_types)
         end
       end
     end

--- a/lib/spree/queries/product/product_properties_query.rb
+++ b/lib/spree/queries/product/product_properties_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(product.id).batch(default_value: []) do |product_ids, loader|
-            Spree::ProductProperty.where(product_id: product_ids).each do |product_property|
-              loader.call(product_property.product_id) { |memo| memo << product_property }
-            end
-          end
+          Spree::Graphql::BatchLoader.for(product, :product_properties)
         end
       end
     end

--- a/lib/spree/queries/product/variants_query.rb
+++ b/lib/spree/queries/product/variants_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(product.id).batch(default_value: []) do |product_ids, loader|
-            Spree::Variant.where(product_id: product_ids, is_master: false).each do |variant|
-              loader.call(variant.product_id) { |memo| memo << variant }
-            end
-          end
+          Spree::Graphql::BatchLoader.for(product, :variants)
         end
       end
     end

--- a/lib/spree/queries/product_property/property_query.rb
+++ b/lib/spree/queries/product_property/property_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(product_property.property_id).batch do |property_ids, loader|
-            Spree::Property.where(id: property_ids).each do |property|
-              loader.call(property.id, property)
-            end
-          end
+          Spree::Graphql::BatchLoader.for(product_property, :property)
         end
       end
     end

--- a/lib/spree/queries/taxon/children_query.rb
+++ b/lib/spree/queries/taxon/children_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(taxon.id).batch(default_value: []) do |taxon_ids, loader|
-            Spree::Taxon.where(parent_id: taxon_ids).each do |children|
-              loader.call(children.parent_id) { |memo| memo << children }
-            end
-          end
+          Spree::Graphql::BatchLoader.for(taxon, :children)
         end
       end
     end

--- a/lib/spree/queries/taxon/parent_taxon_query.rb
+++ b/lib/spree/queries/taxon/parent_taxon_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(taxon.parent_id).batch do |parent_taxon_ids, loader|
-            Spree::Taxon.where(id: parent_taxon_ids).each do |parent_taxon|
-              loader.call(parent_taxon.id, parent_taxon)
-            end
-          end
+          Spree::Graphql::BatchLoader.for(taxon, :parent)
         end
       end
     end

--- a/lib/spree/queries/taxonomy/root_taxon_query.rb
+++ b/lib/spree/queries/taxonomy/root_taxon_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(taxonomy.id).batch(default_value: []) do |taxonomy_ids, loader|
-            Spree::Taxon.where(taxonomy_id: taxonomy_ids, parent_id: nil).each do |taxon|
-              loader.call(taxon.taxonomy_id, taxon)
-            end
-          end
+          Spree::Graphql::BatchLoader.for(taxonomy, :root)
         end
       end
     end

--- a/lib/spree/queries/taxonomy/taxons_query.rb
+++ b/lib/spree/queries/taxonomy/taxons_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(taxonomy.id).batch(default_value: []) do |taxonomy_ids, loader|
-            Spree::Taxon.where(taxonomy_id: taxonomy_ids).each do |taxon|
-              loader.call(taxon.taxonomy_id) { |memo| memo << taxon }
-            end
-          end
+          Spree::Graphql::BatchLoader.for(taxonomy, :taxons)
         end
       end
     end

--- a/lib/spree/queries/variant/option_values_query.rb
+++ b/lib/spree/queries/variant/option_values_query.rb
@@ -11,19 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(variant.id).batch(default_value: []) do |variant_ids, loader|
-            option_values_by_variant_ids(variant_ids).each do |variant_id, option_values|
-              loader.call(variant_id) { |memo| memo.concat(option_values) }
-            end
-          end
-        end
-
-        def option_values_by_variant_ids(variant_ids)
-          result = Hash.new { |h, k| h[k] = [] }
-          Spree::OptionValue.includes(:variants).where("spree_option_values_variants.variant_id": variant_ids).each do |option_value|
-            option_value.variants.each { |variant| result[variant.id] << option_value }
-          end
-          result
+          Spree::Graphql::BatchLoader.for(variant, :option_values)
         end
       end
     end

--- a/lib/spree/queries/variant/prices_query.rb
+++ b/lib/spree/queries/variant/prices_query.rb
@@ -11,11 +11,7 @@ module Spree
         end
 
         def call
-          BatchLoader::GraphQL.for(variant.id).batch(default_value: []) do |variant_ids, loader|
-            Spree::Price.where(variant_id: variant_ids).each do |price|
-              loader.call(price.variant_id) { |memo| memo << price }
-            end
-          end
+          Spree::Graphql::BatchLoader.for(variant, :prices)
         end
       end
     end

--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-rspec', '~> 1.33.0'
   s.add_development_dependency 'simplecov', '~> 0.16.1'
   s.add_development_dependency 'sqlite3', '~> 1.4.1'
+  s.add_development_dependency 'with_model', '~> 2.1.2'
 end

--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'graphql', '~> 1.9.7'
   s.add_dependency 'solidus_core', '>= 2.5'
 
-  s.add_development_dependency 'byebug', '~> 11.0.1'
   s.add_development_dependency 'database_cleaner', '~> 1.7.0'
   s.add_development_dependency 'factory_bot', '~> 5.0.2'
   s.add_development_dependency 'ffaker', '~> 2.11.0'
   s.add_development_dependency 'graphql-schema_comparator', '~> 0.6.1'
+  s.add_development_dependency 'pry', '~> 0.12.2'
   s.add_development_dependency 'rspec-rails', '~> 3.8.2'
   s.add_development_dependency 'rubocop', '~> 0.72.0'
   s.add_development_dependency 'rubocop-rspec', '~> 1.33.0'

--- a/spec/lib/spree/graphql/batch_loader/belongs_to_spec.rb
+++ b/spec/lib/spree/graphql/batch_loader/belongs_to_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Graphql::BatchLoader::BelongsTo do
+  subject(:loader) do
+    described_class.new(
+      object,
+      object.class.reflect_on_association(association),
+      options
+    )
+  end
+
+  let(:options) { {} }
+
+  context 'with a regular association' do
+    with_model :Article do
+      model do
+        has_many :comments
+      end
+    end
+
+    with_model :Comment do
+      table do |t|
+        t.belongs_to :article
+      end
+
+      model do
+        belongs_to :article
+      end
+    end
+
+    let!(:object) { Comment.create!(article: Article.create!) }
+    let(:association) { :article }
+
+    it 'loads the association properly' do
+      expect(loader.load.sync).to eq(object.article)
+    end
+  end
+
+  context 'with a polymorphic association' do
+    with_model :Image do
+      table do |t|
+        t.integer :imageable_id
+        t.string :imageable_type
+      end
+
+      model do
+        belongs_to :imageable, polymorphic: true
+      end
+    end
+
+    with_model :Article do
+      model do
+        has_many :images, as: :imageable
+      end
+    end
+
+    let!(:object) { Image.create!(imageable: Article.create!) }
+    let(:association) { :imageable }
+    let(:options) { { klass: Article } }
+
+    it 'loads the association properly' do
+      expect(loader.load.sync).to eq(object.imageable)
+    end
+  end
+end

--- a/spec/lib/spree/graphql/batch_loader/has_many_spec.rb
+++ b/spec/lib/spree/graphql/batch_loader/has_many_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Graphql::BatchLoader::HasMany do
+  subject(:loader) do
+    described_class.new(
+      article,
+      Article.reflect_on_association(:comments)
+    )
+  end
+
+  with_model :Article do
+    model do
+      has_many :comments
+    end
+  end
+
+  with_model :Comment do
+    table do |t|
+      t.belongs_to :article
+    end
+
+    model do
+      belongs_to :article
+    end
+  end
+
+  let!(:article) { Article.create! }
+
+  before do
+    article.comments.create!
+  end
+
+  it 'loads the association properly' do
+    expect(loader.load.sync).to eq(article.comments)
+  end
+end

--- a/spec/lib/spree/graphql/batch_loader/has_many_through_spec.rb
+++ b/spec/lib/spree/graphql/batch_loader/has_many_through_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Graphql::BatchLoader::HasManyThrough do
+  subject(:loader) do
+    described_class.new(
+      article,
+      Article.reflect_on_association(:comment_authors)
+    )
+  end
+
+  with_model :Article do
+    model do
+      has_many :comments
+      has_many :comment_authors, through: :comments, source: :author
+    end
+  end
+
+  with_model :Comment do
+    table do |t|
+      t.belongs_to :article
+      t.belongs_to :author
+    end
+
+    model do
+      belongs_to :article
+      belongs_to :author
+    end
+  end
+
+  with_model :Author do
+    model do
+      has_many :comments
+    end
+  end
+
+  let!(:article) { Article.create! }
+
+  before do
+    article.comments.create!(author: Author.create!)
+  end
+
+  it 'loads the association properly' do
+    expect(loader.load.sync).to eq(article.comment_authors)
+  end
+end

--- a/spec/lib/spree/graphql/batch_loader/has_one_spec.rb
+++ b/spec/lib/spree/graphql/batch_loader/has_one_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Graphql::BatchLoader::HasOne do
+  subject(:loader) do
+    described_class.new(
+      article,
+      Article.reflect_on_association(:image)
+    )
+  end
+
+  with_model :Article do
+    model do
+      has_one :image
+    end
+  end
+
+  with_model :Image do
+    table do |t|
+      t.belongs_to :article
+    end
+
+    model do
+      belongs_to :article
+    end
+  end
+
+  let!(:article) { Article.create! }
+
+  before do
+    article.create_image!
+  end
+
+  it 'loads the association properly' do
+    expect(loader.load.sync).to eq(article.image)
+  end
+end

--- a/spec/lib/spree/queries/product/master_variant_query_spec.rb
+++ b/spec/lib/spree/queries/product/master_variant_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe Spree::Queries::Product::MasterVariantQuery do
 
   let!(:variants) { create_list(:variant, 2, product: product) }
 
-  it { expect(described_class.new(product: product).call).to eq(product.master) }
+  it { expect(described_class.new(product: product).call.sync).to eq(product.master) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require File.expand_path('dummy/config/environment.rb', __dir__)
 require 'solidus_support/extension/rails_helper.rb'
 
 require "graphql/schema_comparator"
+require 'with_model'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
@@ -30,4 +31,6 @@ RSpec.configure do |config|
   config.before(:each) do
     BatchLoader::Executor.clear_current
   end
+
+  config.extend WithModel
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require File.expand_path('dummy/config/environment.rb', __dir__)
 
 # Requires factories and other useful helpers defined in spree_core.
 require 'solidus_support/extension/rails_helper.rb'
+require 'pry'
 
 require "graphql/schema_comparator"
 require 'with_model'


### PR DESCRIPTION
## Summary

This implements a batch-loading framework that creates a layer on top of [batch-loader](https://github.com/exAspArk/batch-loader) to allow us to batch-load with a single line of code:

```ruby
Spree::Graphql::BatchLoader.for(user, :posts)
```

The class will automatically recognize the association type and use the appropriate batch-loading logic. It also allows to customize certain aspects of the batch-loading process (YARD documentation is provided for the different options), for instance by allowing to pass a custom scope to the association.

## Future improvements

- We may consider extracting this into a separate gem, since it is completely independent from Solidus/GraphQL. The only improvement to do in this case would be to allow people to choose if they want to use `BatchLoader` or `BatchLoader::GraphQL`.