### PR TITLE
Type Customization API

### DIFF
--- a/lib/solidus_graphql_api/types/base/object.rb
+++ b/lib/solidus_graphql_api/types/base/object.rb
@@ -4,6 +4,21 @@ module SolidusGraphqlApi
   module Types
     module Base
       class Object < GraphQL::Schema::Object
+        class << self
+          # Removes a field from this schema.
+          #
+          # @param field [Symbol] the field to remove
+          #
+          # @example Removing a field in a decorator
+          #   Spree::Graphql::Types::Variant.remove_field :prices
+          def remove_field(field)
+            unless own_fields.key?(field.to_s)
+              raise ArgumentError, "Field `#{field}` is not defined"
+            end
+
+            own_fields.delete(field.to_s)
+          end
+        end
       end
     end
   end

--- a/spec/lib/solidus_graphql_api/types/base/object_spec.rb
+++ b/spec/lib/solidus_graphql_api/types/base/object_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Types::Base::Object do
+  subject { Class.new(described_class) }
+
+  describe '.remove_field' do
+    context 'when the field is defined' do
+      before do
+        subject.field :name, String, null: false
+      end
+
+      it 'removes the field' do
+        expect {
+          subject.remove_field :name
+        }.to change { subject.own_fields['name'] }.to(nil)
+      end
+    end
+
+    context 'when the field is not defined' do
+      it 'raises an ArgumentError' do
+        expect {
+          subject.remove_field :name
+        }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows users to customize our implementation by providing the ability to remove previously defined fields (via `.remove_field`).

Fields can already be redefined by calling `field` again, so we shouldn't need much more.