### PR TITLE
Add products field to the root query

### DIFF
--- a/lib/spree/graphql/types/option_type.rb
+++ b/lib/spree/graphql/types/option_type.rb
@@ -4,7 +4,9 @@ module Spree
   module Graphql
     module Types
       class OptionType < Base::RelayNode
-        description 'Option Type.'
+        graphql_name 'OptionType'
+
+        description 'OptionType Type.'
 
         field :name, String, null: false
         field :presentation, String, null: false

--- a/lib/spree/graphql/types/product.rb
+++ b/lib/spree/graphql/types/product.rb
@@ -13,12 +13,17 @@ module Spree
         field :meta_keywords, String, null: true
         field :meta_title, String, null: true
         field :name, String, null: false
+        field :option_types, Types::OptionType.connection_type, null: false
         field :slug, String, null: false
         field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
         field :variants, Types::Variant.connection_type, null: false
 
         def master_variant
           Spree::Queries::Product::MasterVariantQuery.new(product: object).call
+        end
+
+        def option_types
+          Spree::Queries::Product::OptionTypesQuery.new(product: object).call
         end
 
         def variants

--- a/lib/spree/graphql/types/product.rb
+++ b/lib/spree/graphql/types/product.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    module Types
+      class Product < Base::RelayNode
+        description 'Product.'
+
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :description, String, null: true
+        field :meta_description, String, null: true
+        field :meta_keywords, String, null: true
+        field :meta_title, String, null: true
+        field :name, String, null: false
+        field :slug, String, null: false
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      end
+    end
+  end
+end

--- a/lib/spree/graphql/types/product.rb
+++ b/lib/spree/graphql/types/product.rb
@@ -14,6 +14,11 @@ module Spree
         field :name, String, null: false
         field :slug, String, null: false
         field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :variants, Types::Variant.connection_type, null: false
+
+        def variants
+          Spree::Queries::Product::VariantsQuery.new(product: object).call
+        end
       end
     end
   end

--- a/lib/spree/graphql/types/product.rb
+++ b/lib/spree/graphql/types/product.rb
@@ -8,6 +8,7 @@ module Spree
 
         field :created_at, GraphQL::Types::ISO8601DateTime, null: true
         field :description, String, null: true
+        field :master_variant, Types::Variant, null: false
         field :meta_description, String, null: true
         field :meta_keywords, String, null: true
         field :meta_title, String, null: true
@@ -15,6 +16,10 @@ module Spree
         field :slug, String, null: false
         field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
         field :variants, Types::Variant.connection_type, null: false
+
+        def master_variant
+          Spree::Queries::Product::MasterVariantQuery.new(product: object).call
+        end
 
         def variants
           Spree::Queries::Product::VariantsQuery.new(product: object).call

--- a/lib/spree/graphql/types/query.rb
+++ b/lib/spree/graphql/types/query.rb
@@ -14,12 +14,20 @@ module Spree
               null: false,
               description: 'Supported Countries.'
 
+        field :products, Types::Product.connection_type,
+              null: false,
+              description: 'Supported Products.'
+
         field :taxonomies, Types::Taxonomy.connection_type,
               null: false,
               description: 'Supported Taxonomies.'
 
         def countries
           Spree::Queries::CountriesQuery.new.call
+        end
+
+        def products
+          Spree::Queries::ProductsQuery.new.call
         end
 
         def taxonomies

--- a/lib/spree/queries/product/master_variant_query.rb
+++ b/lib/spree/queries/product/master_variant_query.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  module Queries
+    module Product
+      class MasterVariantQuery
+        attr_reader :product
+
+        def initialize(product:)
+          @product = product
+        end
+
+        def call
+          BatchLoader.for(product.id).batch do |product_ids, loader|
+            Spree::Variant.where(is_master: true).where(product_id: product_ids).each do |variant|
+              loader.call(variant.product_id, variant)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/queries/product/option_types_query.rb
+++ b/lib/spree/queries/product/option_types_query.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Spree
+  module Queries
+    module Product
+      class OptionTypesQuery
+        attr_reader :product
+
+        def initialize(product:)
+          @product = product
+        end
+
+        def call
+          BatchLoader::GraphQL.for(product.id).batch(default_value: []) do |product_ids, loader|
+            option_types_by_variant_ids(product_ids).each do |product_id, option_types|
+              loader.call(product_id) { |memo| memo.concat(option_types) }
+            end
+          end
+        end
+
+        private
+
+        def option_types_by_variant_ids(product_ids)
+          result = Hash.new { |h, k| h[k] = [] }
+          Spree::OptionType.includes(:products).where("spree_product_option_types.product_id": product_ids).each do |option_type|
+            option_type.products.each { |product| result[product.id] << option_type }
+          end
+          result
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/queries/product/variants_query.rb
+++ b/lib/spree/queries/product/variants_query.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  module Queries
+    module Product
+      class VariantsQuery
+        attr_reader :product
+
+        def initialize(product:)
+          @product = product
+        end
+
+        def call
+          BatchLoader::GraphQL.for(product.id).batch(default_value: []) do |product_ids, loader|
+            Spree::Variant.where(product_id: product_ids, is_master: false).each do |variant|
+              loader.call(variant.product_id) { |memo| memo << variant }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/queries/products_query.rb
+++ b/lib/spree/queries/products_query.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module Queries
+    class ProductsQuery
+      def call
+        Spree::Product.all
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -85,6 +85,121 @@ interface Node {
 }
 
 """
+OptionType Type.
+"""
+type OptionType implements Node {
+  createdAt: ISO8601DateTime
+  id: ID!
+  name: String!
+  optionValues(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): OptionValueConnection!
+  position: Int!
+  presentation: String!
+  updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for OptionType.
+"""
+type OptionTypeConnection {
+  """
+  A list of edges.
+  """
+  edges: [OptionTypeEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [OptionType]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type OptionTypeEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: OptionType
+}
+
+"""
+OptionValue.
+"""
+type OptionValue implements Node {
+  createdAt: ISO8601DateTime
+  id: ID!
+  name: String!
+  position: String!
+  presentation: String!
+  updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for OptionValue.
+"""
+type OptionValueConnection {
+  """
+  A list of edges.
+  """
+  edges: [OptionValueEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [OptionValue]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type OptionValueEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: OptionValue
+}
+
+"""
 Information about pagination in a connection.
 """
 type PageInfo {
@@ -107,6 +222,149 @@ type PageInfo {
   When paginating backwards, the cursor to continue.
   """
   startCursor: String
+}
+
+"""
+Price.
+"""
+type Price implements Node {
+  amount: String!
+  countryIso: String
+  createdAt: ISO8601DateTime
+  currency: String!
+  currencySymbol: String!
+  displayAmount: String!
+  displayCountry: String!
+  id: ID!
+  updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for Price.
+"""
+type PriceConnection {
+  """
+  A list of edges.
+  """
+  edges: [PriceEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Price]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type PriceEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Price
+}
+
+"""
+Product.
+"""
+type Product implements Node {
+  createdAt: ISO8601DateTime
+  description: String
+  id: ID!
+  masterVariant: Variant!
+  metaDescription: String
+  metaKeywords: String
+  metaTitle: String
+  name: String!
+  optionTypes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): OptionTypeConnection!
+  slug: String!
+  updatedAt: ISO8601DateTime
+  variants(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): VariantConnection!
+}
+
+"""
+The connection type for Product.
+"""
+type ProductConnection {
+  """
+  A list of edges.
+  """
+  edges: [ProductEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Product]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type ProductEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Product
 }
 
 type Query {
@@ -154,6 +412,31 @@ type Query {
     """
     ids: [ID!]!
   ): [Node]!
+
+  """
+  Supported Products.
+  """
+  products(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): ProductConnection!
 
   """
   Supported Taxonomies.
@@ -365,4 +648,98 @@ type TaxonomyEdge {
   The item at the end of the edge.
   """
   node: Taxonomy
+}
+
+"""
+Variant.
+"""
+type Variant implements Node {
+  createdAt: ISO8601DateTime
+  defaultPrice: Price!
+  depth: String
+  height: String
+  id: ID!
+  isMaster: Boolean!
+  optionValues(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): OptionValueConnection!
+  position: Int!
+  prices(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): PriceConnection!
+  sku: String!
+  updatedAt: ISO8601DateTime
+  weight: String!
+  width: String
+}
+
+"""
+The connection type for Variant.
+"""
+type VariantConnection {
+  """
+  A list of edges.
+  """
+  edges: [VariantEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Variant]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type VariantEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Variant
 }

--- a/spec/expected_schema.graphql
+++ b/spec/expected_schema.graphql
@@ -45,6 +45,31 @@ type Query {
   ): [Node]!
 
   """
+  Supported Products.
+  """
+  products(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): ProductConnection!
+
+  """
   Supported Taxonomies.
   """
   taxonomies(
@@ -226,6 +251,56 @@ type StateEdge {
   The item at the end of the edge.
   """
   node: State
+}
+
+"""
+Product.
+"""
+type Product implements Node {
+ createdAt: ISO8601DateTime
+ description: String
+ id: ID!
+ metaDescription: String
+ metaKeywords: String
+ metaTitle: String
+ name: String!
+ slug: String!
+ updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for Product.
+"""
+type ProductConnection {
+ """
+ A list of edges.
+ """
+ edges: [ProductEdge]
+
+ """
+ A list of nodes.
+ """
+ nodes: [Product]
+
+ """
+ Information to aid in pagination.
+ """
+ pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type ProductEdge {
+ """
+ A cursor for use in pagination.
+ """
+ cursor: String!
+
+ """
+ The item at the end of the edge.
+ """
+ node: Product
 }
 
 """

--- a/spec/expected_schema.graphql
+++ b/spec/expected_schema.graphql
@@ -265,6 +265,27 @@ type Product implements Node {
  metaKeywords: String
  metaTitle: String
  name: String!
+ optionTypes(
+   """
+   Returns the elements in the list that come after the specified cursor.
+   """
+   after: String
+
+   """
+   Returns the elements in the list that come before the specified cursor.
+   """
+   before: String
+
+   """
+   Returns the first _n_ elements from the list.
+   """
+   first: Int
+
+   """
+   Returns the last _n_ elements from the list.
+   """
+   last: Int
+ ): OptionTypeConnection!
  slug: String!
  updatedAt: ISO8601DateTime
  variants(
@@ -655,4 +676,72 @@ type VariantEdge {
  The item at the end of the edge.
  """
  node: Variant
+}
+
+"""
+OptionType Type.
+"""
+type OptionType implements Node {
+ createdAt: ISO8601DateTime
+ id: ID!
+ name: String!
+ optionValues(
+   """
+   Returns the elements in the list that come after the specified cursor.
+   """
+   after: String
+
+   """
+   Returns the elements in the list that come before the specified cursor.
+   """
+   before: String
+
+   """
+   Returns the first _n_ elements from the list.
+   """
+   first: Int
+
+   """
+   Returns the last _n_ elements from the list.
+   """
+   last: Int
+ ): OptionValueConnection!
+ position: Int!
+ presentation: String!
+ updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for OptionType.
+"""
+type OptionTypeConnection {
+ """
+ A list of edges.
+ """
+ edges: [OptionTypeEdge]
+
+ """
+ A list of nodes.
+ """
+ nodes: [OptionType]
+
+ """
+ Information to aid in pagination.
+ """
+ pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type OptionTypeEdge {
+ """
+ A cursor for use in pagination.
+ """
+ cursor: String!
+
+ """
+ The item at the end of the edge.
+ """
+ node: OptionType
 }

--- a/spec/expected_schema.graphql
+++ b/spec/expected_schema.graphql
@@ -266,6 +266,27 @@ type Product implements Node {
  name: String!
  slug: String!
  updatedAt: ISO8601DateTime
+ variants(
+   """
+   Returns the elements in the list that come after the specified cursor.
+   """
+   after: String
+
+   """
+   Returns the elements in the list that come before the specified cursor.
+   """
+   before: String
+
+   """
+   Returns the first _n_ elements from the list.
+   """
+   first: Int
+
+   """
+   Returns the last _n_ elements from the list.
+   """
+   last: Int
+ ): VariantConnection!
 }
 
 """
@@ -429,6 +450,183 @@ type TaxonConnection {
 }
 
 """
+OptionValue.
+"""
+type OptionValue implements Node {
+ createdAt: ISO8601DateTime
+ id: ID!
+ name: String!
+ position: String!
+ presentation: String!
+ updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for OptionValue.
+"""
+type OptionValueConnection {
+ """
+ A list of edges.
+ """
+ edges: [OptionValueEdge]
+
+ """
+ A list of nodes.
+ """
+ nodes: [OptionValue]
+
+ """
+ Information to aid in pagination.
+ """
+ pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type OptionValueEdge {
+ """
+ A cursor for use in pagination.
+ """
+ cursor: String!
+
+ """
+ The item at the end of the edge.
+ """
+ node: OptionValue
+}
+
+
+"""
+Price.
+"""
+type Price implements Node {
+ amount: String!
+ countryIso: String
+ createdAt: ISO8601DateTime
+ currency: String!
+ currencySymbol: String!
+ displayAmount: String!
+ displayCountry: String!
+ id: ID!
+ updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for Price.
+"""
+type PriceConnection {
+ """
+ A list of edges.
+ """
+ edges: [PriceEdge]
+
+ """
+ A list of nodes.
+ """
+ nodes: [Price]
+
+ """
+ Information to aid in pagination.
+ """
+ pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type PriceEdge {
+ """
+ A cursor for use in pagination.
+ """
+ cursor: String!
+
+ """
+ The item at the end of the edge.
+ """
+ node: Price
+}
+
+"""
+Variant.
+"""
+type Variant implements Node {
+ createdAt: ISO8601DateTime
+ defaultPrice: Price!
+ depth: String
+ height: String
+ id: ID!
+ isMaster: Boolean!
+ optionValues(
+   """
+   Returns the elements in the list that come after the specified cursor.
+   """
+   after: String
+
+   """
+   Returns the elements in the list that come before the specified cursor.
+   """
+   before: String
+
+   """
+   Returns the first _n_ elements from the list.
+   """
+   first: Int
+
+   """
+   Returns the last _n_ elements from the list.
+   """
+   last: Int
+ ): OptionValueConnection!
+ position: Int!
+ prices(
+   """
+   Returns the elements in the list that come after the specified cursor.
+   """
+   after: String
+
+   """
+   Returns the elements in the list that come before the specified cursor.
+   """
+   before: String
+
+   """
+   Returns the first _n_ elements from the list.
+   """
+   first: Int
+
+   """
+   Returns the last _n_ elements from the list.
+   """
+   last: Int
+ ): PriceConnection!
+ sku: String!
+ updatedAt: ISO8601DateTime
+ weight: String!
+ width: String
+}
+
+"""
+The connection type for Variant.
+"""
+type VariantConnection {
+ """
+ A list of edges.
+ """
+ edges: [VariantEdge]
+
+ """
+ A list of nodes.
+ """
+ nodes: [Variant]
+
+ """
+ Information to aid in pagination.
+ """
+ pageInfo: PageInfo!
+}
+
+"""
 An edge in a connection.
 """
 type TaxonEdge {
@@ -441,4 +639,19 @@ type TaxonEdge {
   The item at the end of the edge.
   """
   node: Taxon
+}
+
+"""
+An edge in a connection.
+"""
+type VariantEdge {
+ """
+ A cursor for use in pagination.
+ """
+ cursor: String!
+
+ """
+ The item at the end of the edge.
+ """
+ node: Variant
 }

--- a/spec/expected_schema.graphql
+++ b/spec/expected_schema.graphql
@@ -260,6 +260,7 @@ type Product implements Node {
  createdAt: ISO8601DateTime
  description: String
  id: ID!
+ masterVariant: Variant!
  metaDescription: String
  metaKeywords: String
  metaTitle: String

--- a/spec/integration/products_spec.rb
+++ b/spec/integration/products_spec.rb
@@ -5,11 +5,23 @@ require 'spec_helper'
 RSpec.describe "Products" do
   include_examples 'query is successful', :products do
     let(:product_nodes) { subject.data.products.nodes }
+    let(:variant_nodes) { product_nodes.map { |product_node| product_node.variants.nodes }.flatten }
+    let(:variant_default_price_nodes) { variant_nodes.map(&:defaultPrice) }
+    let(:variant_option_value_nodes) { variant_nodes.map { |variant_node| variant_node.optionValues.nodes }.flatten }
+    let(:variant_price_nodes) { variant_nodes.map { |variant_node| variant_node.prices.nodes }.flatten }
 
     before do
-      create_list(:product, 2)
+      create_list(:variant, 2)
     end
 
     it { expect(product_nodes).to be_present }
+
+    it { expect(variant_nodes).to be_present }
+
+    it { expect(variant_default_price_nodes).to be_present }
+
+    it { expect(variant_option_value_nodes).to be_present }
+
+    it { expect(variant_price_nodes).to be_present }
   end
 end

--- a/spec/integration/products_spec.rb
+++ b/spec/integration/products_spec.rb
@@ -6,18 +6,29 @@ RSpec.describe "Products" do
   include_examples 'query is successful', :products do
     let(:product_nodes) { subject.data.products.nodes }
     let(:master_variant_nodes) { product_nodes.map(&:masterVariant) }
+    let(:option_type_nodes) { product_nodes.map { |product_node| product_node.optionTypes.nodes }.flatten }
+    let(:option_value_nodes) { option_type_nodes.map { |option_type| option_type.optionValues.nodes }.flatten }
     let(:variant_nodes) { product_nodes.map { |product_node| product_node.variants.nodes }.flatten }
     let(:variant_default_price_nodes) { variant_nodes.map(&:defaultPrice) }
     let(:variant_option_value_nodes) { variant_nodes.map { |variant_node| variant_node.optionValues.nodes }.flatten }
     let(:variant_price_nodes) { variant_nodes.map { |variant_node| variant_node.prices.nodes }.flatten }
 
+    let(:product) { create(:product_with_option_types) }
+
     before do
-      create_list(:variant, 2)
+      product.option_types.each do |option_type|
+        create(:option_value, option_type: option_type)
+      end
+      create_list(:variant, 2, product: product)
     end
 
     it { expect(product_nodes).to be_present }
 
     it { expect(master_variant_nodes).to be_present }
+
+    it { expect(option_type_nodes).to be_present }
+
+    it { expect(option_value_nodes).to be_present }
 
     it { expect(variant_nodes).to be_present }
 

--- a/spec/integration/products_spec.rb
+++ b/spec/integration/products_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 RSpec.describe "Products" do
   include_examples 'query is successful', :products do
     let(:product_nodes) { subject.data.products.nodes }
+    let(:master_variant_nodes) { product_nodes.map(&:masterVariant) }
     let(:variant_nodes) { product_nodes.map { |product_node| product_node.variants.nodes }.flatten }
     let(:variant_default_price_nodes) { variant_nodes.map(&:defaultPrice) }
     let(:variant_option_value_nodes) { variant_nodes.map { |variant_node| variant_node.optionValues.nodes }.flatten }
@@ -15,6 +16,8 @@ RSpec.describe "Products" do
     end
 
     it { expect(product_nodes).to be_present }
+
+    it { expect(master_variant_nodes).to be_present }
 
     it { expect(variant_nodes).to be_present }
 

--- a/spec/integration/products_spec.rb
+++ b/spec/integration/products_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "Products" do
+  include_examples 'query is successful', :products do
+    let(:product_nodes) { subject.data.products.nodes }
+
+    before do
+      create_list(:product, 2)
+    end
+
+    it { expect(product_nodes).to be_present }
+  end
+end

--- a/spec/lib/spree/graphql/types/product_spec.rb
+++ b/spec/lib/spree/graphql/types/product_spec.rb
@@ -8,6 +8,18 @@ RSpec.describe Spree::Graphql::Types::Product do
 
   subject { described_class.send(:new, product, {}) }
 
+  describe '#master_variant' do
+    before do
+      allow(Spree::Queries::Product::MasterVariantQuery).to receive(:new).and_return(query_object)
+    end
+
+    after { subject.master_variant }
+
+    it { expect(Spree::Queries::Product::MasterVariantQuery).to receive(:new).with(product: product) }
+
+    it { expect(query_object).to receive(:call) }
+  end
+
   describe '#variants' do
     before do
       allow(Spree::Queries::Product::VariantsQuery).to receive(:new).and_return(query_object)

--- a/spec/lib/spree/graphql/types/product_spec.rb
+++ b/spec/lib/spree/graphql/types/product_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Spree::Graphql::Types::Product do
     it { expect(query_object).to receive(:call) }
   end
 
+  describe '#option_types' do
+    before do
+      allow(Spree::Queries::Product::OptionTypesQuery).to receive(:new).and_return(query_object)
+    end
+
+    after { subject.option_types }
+
+    it { expect(Spree::Queries::Product::OptionTypesQuery).to receive(:new).with(product: product) }
+
+    it { expect(query_object).to receive(:call) }
+  end
+
   describe '#variants' do
     before do
       allow(Spree::Queries::Product::VariantsQuery).to receive(:new).and_return(query_object)

--- a/spec/lib/spree/graphql/types/product_spec.rb
+++ b/spec/lib/spree/graphql/types/product_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Graphql::Types::Product do
+  let(:product) { create(:product) }
+  let(:query_object) { spy(:query_object) }
+
+  subject { described_class.send(:new, product, {}) }
+
+  describe '#variants' do
+    before do
+      allow(Spree::Queries::Product::VariantsQuery).to receive(:new).and_return(query_object)
+    end
+
+    after { subject.variants }
+
+    it { expect(Spree::Queries::Product::VariantsQuery).to receive(:new).with(product: product) }
+
+    it { expect(query_object).to receive(:call) }
+  end
+end

--- a/spec/lib/spree/graphql/types/query_spec.rb
+++ b/spec/lib/spree/graphql/types/query_spec.rb
@@ -3,6 +3,20 @@
 require 'spec_helper'
 
 RSpec.describe Spree::Graphql::Types::Query do
+  subject { described_class.send(:new, {}, {}) }
+
   it { expect(described_class.method_defined?(:countries)).to be_truthy }
   it { expect(described_class.method_defined?(:taxonomies)).to be_truthy }
+
+  describe '#products' do
+    let(:query_object) { spy(:query_object) }
+
+    before { allow(Spree::Queries::ProductsQuery).to receive(:new).and_return(query_object) }
+
+    after { subject.products }
+
+    it { expect(Spree::Queries::ProductsQuery).to receive(:new) }
+
+    it { expect(query_object).to receive(:call) }
+  end
 end

--- a/spec/lib/spree/queries/product/master_variant_query_spec.rb
+++ b/spec/lib/spree/queries/product/master_variant_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Queries::Product::MasterVariantQuery do
+  let(:product) { create(:product) }
+
+  let!(:variants) { create_list(:variant, 2, product: product) }
+
+  it { expect(described_class.new(product: product).call).to eq(product.master) }
+end

--- a/spec/lib/spree/queries/product/option_types_query_spec.rb
+++ b/spec/lib/spree/queries/product/option_types_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Queries::Product::OptionTypesQuery do
+  let(:product) { create(:product) }
+
+  let!(:option_types) { create_list(:option_type, 2, products: [product]) }
+
+  it { expect(described_class.new(product: product).call.sync).to eq(option_types) }
+end

--- a/spec/lib/spree/queries/product/variants_query_spec.rb
+++ b/spec/lib/spree/queries/product/variants_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Queries::Product::VariantsQuery do
+  let(:product) { create(:product) }
+
+  let!(:variants) { create_list(:variant, 2, product: product) }
+
+  it { expect(described_class.new(product: product).call.sync).to eq(variants) }
+end

--- a/spec/lib/spree/queries/products_query_spec.rb
+++ b/spec/lib/spree/queries/products_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Queries::ProductsQuery do
+  subject { described_class.new.call }
+
+  let!(:products) { create_list(:product, 2) }
+
+  it { is_expected.to eq(products) }
+end

--- a/spec/queries/products.gql
+++ b/spec/queries/products.gql
@@ -4,6 +4,9 @@ query {
       createdAt
       description
       id
+      masterVariant {
+        id
+      }
       metaDescription
       metaKeywords
       metaTitle

--- a/spec/queries/products.gql
+++ b/spec/queries/products.gql
@@ -1,0 +1,15 @@
+query {
+  products {
+    nodes {
+      createdAt
+      description
+      id
+      metaDescription
+      metaKeywords
+      metaTitle
+      name
+      slug
+      updatedAt
+    }
+  }
+}

--- a/spec/queries/products.gql
+++ b/spec/queries/products.gql
@@ -10,6 +10,54 @@ query {
       name
       slug
       updatedAt
+      variants {
+        nodes {
+          createdAt
+          defaultPrice {
+            amount
+            countryIso
+            createdAt
+            currency
+            currencySymbol
+            displayAmount
+            displayCountry
+            id
+            updatedAt
+          }
+          depth
+          height
+          id
+          isMaster
+          optionValues {
+            nodes {
+              createdAt
+              id
+              name
+              position
+              presentation
+              updatedAt
+            }
+          }
+          position
+          prices {
+            nodes {
+              amount
+              countryIso
+              createdAt
+              currency
+              currencySymbol
+              displayAmount
+              displayCountry
+              id
+              updatedAt
+            }
+          }
+          sku
+          updatedAt
+          weight
+          width
+        }
+      }
     }
   }
 }

--- a/spec/queries/products.gql
+++ b/spec/queries/products.gql
@@ -11,6 +11,26 @@ query {
       metaKeywords
       metaTitle
       name
+      optionTypes {
+        nodes {
+          createdAt
+          id
+          name
+          optionValues {
+            nodes {
+              createdAt
+              id
+              name
+              position
+              presentation
+              updatedAt
+            }
+          }
+          position
+          presentation
+          updatedAt
+        }
+      }
       slug
       updatedAt
       variants {


### PR DESCRIPTION
Add `products` field to the root query, the Product Type has the basic fields, `variants` and `option_types` connections, and the `master variant`.