### PR TITLE
Disable the cache for all the `BatchLoader` run in the tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,4 +26,8 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
   config.include Helpers::Graphql
+
+  config.before(:each) do
+    BatchLoader::Executor.clear_current
+  end
 end


### PR DESCRIPTION
Enabled cache causes random problems in BatchLoader specs execution.

For more info:
https://github.com/exAspArk/batch-loader#caching