### PR TITLE
Add ProductProperty Type

### DIFF
--- a/lib/spree/graphql/types/product_property.rb
+++ b/lib/spree/graphql/types/product_property.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Spree
+  module Graphql
+    module Types
+      class ProductProperty < Base::RelayNode
+        description 'Product Property.'
+
+        field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :position, Int, null: false
+        field :property, Types::Property, null: true
+        field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+        field :value, String, null: false
+
+        def property
+          Spree::Queries::ProductProperty::PropertyQuery.new(product_property: object).call
+        end
+      end
+    end
+  end
+end

--- a/lib/spree/queries/product_property/property_query.rb
+++ b/lib/spree/queries/product_property/property_query.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Spree
+  module Queries
+    module ProductProperty
+      class PropertyQuery
+        attr_reader :product_property
+
+        def initialize(product_property:)
+          @product_property = product_property
+        end
+
+        def call
+          BatchLoader::GraphQL.for(product_property.property_id).batch do |property_ids, loader|
+            Spree::Property.where(id: property_ids).each do |property|
+              loader.call(property.id, property)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/spree/graphql/types/product_property_spec.rb
+++ b/spec/lib/spree/graphql/types/product_property_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Graphql::Types::ProductProperty do
+  let(:product_property) { double(:product_property) }
+  let(:query_object) { spy(:query_object) }
+
+  subject { described_class.send(:new, product_property, {}) }
+
+  describe '#property' do
+    let(:query_class) { Spree::Queries::ProductProperty::PropertyQuery }
+
+    before { allow(query_class).to receive(:new).and_return(query_object) }
+
+    after { subject.property }
+
+    it { expect(query_class).to receive(:new).with(product_property: product_property) }
+
+    it { expect(query_object).to receive(:call) }
+  end
+end

--- a/spec/lib/spree/queries/product_property/property_query_spec.rb
+++ b/spec/lib/spree/queries/product_property/property_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Queries::ProductProperty::PropertyQuery do
+  let(:property) { create(:property) }
+
+  let!(:product_property) { create(:product_property, property: property) }
+
+  it { expect(described_class.new(product_property: product_property).call.sync).to eq(property) }
+end


### PR DESCRIPTION
Add `ProductProperty` Type that will be used in the `Product` Type.
It has basic fields and the `property` field loaded with the batch loader inside a query object.