### PR TITLE
Add product_by_slug field to root query

### DIFF
--- a/lib/spree/graphql/types/query.rb
+++ b/lib/spree/graphql/types/query.rb
@@ -18,6 +18,12 @@ module Spree
               null: false,
               description: 'Supported Products.'
 
+        field :product_by_slug, Types::Product,
+              null: true,
+              description: 'Find a product by its slug.' do
+                argument :slug, String, required: true
+              end
+
         field :taxonomies, Types::Taxonomy.connection_type,
               null: false,
               description: 'Supported Taxonomies.'
@@ -28,6 +34,10 @@ module Spree
 
         def products
           Spree::Queries::ProductsQuery.new.call
+        end
+
+        def product_by_slug(slug:)
+          Spree::Queries::ProductBySlugQuery.new.call(slug: slug)
         end
 
         def taxonomies

--- a/lib/spree/queries/product_by_slug_query.rb
+++ b/lib/spree/queries/product_by_slug_query.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Spree
+  module Queries
+    class ProductBySlugQuery
+      def call(slug:)
+        Spree::Product.find_by slug: slug
+      end
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -493,6 +493,11 @@ type Query {
   ): [Node]!
 
   """
+  Find a product by its slug.
+  """
+  productBySlug(slug: String!): Product
+
+  """
   Supported Products.
   """
   products(

--- a/spec/expected_schema.graphql
+++ b/spec/expected_schema.graphql
@@ -45,6 +45,11 @@ type Query {
   ): [Node]!
 
   """
+  Find a product by its slug.
+  """
+  productBySlug(slug: String!): Product
+
+  """
   Supported Products.
   """
   products(

--- a/spec/integration/product_by_slug_spec.rb
+++ b/spec/integration/product_by_slug_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "ProductBySlug" do
+  include_examples 'query is successful', :product_by_slug do
+    let!(:product) { create(:product, slug: 'slug') }
+  end
+end

--- a/spec/lib/spree/graphql/types/query_spec.rb
+++ b/spec/lib/spree/graphql/types/query_spec.rb
@@ -19,4 +19,16 @@ RSpec.describe Spree::Graphql::Types::Query do
 
     it { expect(query_object).to receive(:call) }
   end
+
+  describe '#product_by_slug' do
+    let(:query_object) { spy(:query_object) }
+
+    let(:slug) { 'slug' }
+
+    before { allow(Spree::Queries::ProductBySlugQuery).to receive(:new).with(no_args).and_return(query_object) }
+
+    after { subject.product_by_slug(slug: slug) }
+
+    it { expect(query_object).to receive(:call).with(slug: slug) }
+  end
 end

--- a/spec/lib/spree/queries/product_by_slug_query_spec.rb
+++ b/spec/lib/spree/queries/product_by_slug_query_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Spree::Queries::ProductBySlugQuery do
+  subject { described_class.new.call(slug: slug) }
+
+  let!(:products) { create_list(:product, 2) }
+  let(:product) { products.last }
+  let(:slug) { product.slug }
+
+  it { is_expected.to eq(product) }
+end

--- a/spec/queries/product_by_slug.gql
+++ b/spec/queries/product_by_slug.gql
@@ -1,0 +1,5 @@
+query {
+  productBySlug(slug: "slug") {
+    id
+  }
+}


### PR DESCRIPTION
The `product_by_slug` field uses the `Spree::Queries::ProductBySlugQuery`
object to retrieve the product by its slug.