### PR TITLE
Add images connection field to Variant Type

### DIFF
--- a/lib/solidus_graphql_api/queries/variant/images_query.rb
+++ b/lib/solidus_graphql_api/queries/variant/images_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Queries
+    module Variant
+      class ImagesQuery
+        attr_reader :variant
+
+        def initialize(variant:)
+          @variant = variant
+        end
+
+        def call
+          SolidusGraphqlApi::BatchLoader.for(variant, :images)
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/image.rb
+++ b/lib/solidus_graphql_api/types/image.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class Image < Base::RelayNode
+      description 'Image.'
+
+      field :alt, String, null: true
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :filename, String, null: false
+      field :large_url, String, null: false
+      field :mini_url, String, null: false
+      field :position, Integer, null: false
+      field :product_url, String, null: false
+      field :small_url, String, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+
+      def large_url; object.url(:large) end
+
+      def mini_url; object.url(:mini) end
+
+      def product_url; object.url(:product) end
+
+      def small_url; object.url(:small) end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/variant.rb
+++ b/lib/solidus_graphql_api/types/variant.rb
@@ -9,6 +9,7 @@ module SolidusGraphqlApi
       field :default_price, Price, null: false
       field :depth, String, null: true
       field :height, String, null: true
+      field :images, Types::Image.connection_type, null: false
       field :is_master, Boolean, null: false
       field :option_values, OptionValue.connection_type, null: false
       field :position, Int, null: false
@@ -20,6 +21,10 @@ module SolidusGraphqlApi
 
       def default_price
         Queries::Variant::DefaultPriceQuery.new(variant: object).call
+      end
+
+      def images
+        Queries::Variant::ImagesQuery.new(variant: object).call
       end
 
       def option_values

--- a/schema.graphql
+++ b/schema.graphql
@@ -75,6 +75,57 @@ An ISO 8601-encoded datetime
 scalar ISO8601DateTime
 
 """
+Image.
+"""
+type Image implements Node {
+  alt: String
+  createdAt: ISO8601DateTime
+  filename: String!
+  id: ID!
+  largeUrl: String!
+  miniUrl: String!
+  position: Int!
+  productUrl: String!
+  smallUrl: String!
+  updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for Image.
+"""
+type ImageConnection {
+  """
+  A list of edges.
+  """
+  edges: [ImageEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Image]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type ImageEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Image
+}
+
+"""
 An object with an ID.
 """
 interface Node {
@@ -762,6 +813,27 @@ type Variant implements Node {
   depth: String
   height: String
   id: ID!
+  images(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): ImageConnection!
   isMaster: Boolean!
   optionValues(
     """

--- a/spec/expected_schema.graphql
+++ b/spec/expected_schema.graphql
@@ -623,6 +623,27 @@ type Variant implements Node {
  depth: String
  height: String
  id: ID!
+ images(
+   """
+   Returns the elements in the list that come after the specified cursor.
+   """
+   after: String
+
+   """
+   Returns the elements in the list that come before the specified cursor.
+   """
+   before: String
+
+   """
+   Returns the first _n_ elements from the list.
+   """
+   first: Int
+
+   """
+   Returns the last _n_ elements from the list.
+   """
+   last: Int
+ ): ImageConnection!
  isMaster: Boolean!
  optionValues(
    """
@@ -847,4 +868,55 @@ type Property implements Node {
  name: String!
  presentation: String!
  updatedAt: ISO8601DateTime
+}
+
+"""
+Image.
+"""
+type Image implements Node {
+  alt: String
+  createdAt: ISO8601DateTime
+  filename: String!
+  id: ID!
+  largeUrl: String!
+  miniUrl: String!
+  position: Int!
+  productUrl: String!
+  smallUrl: String!
+  updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for Image.
+"""
+type ImageConnection {
+  """
+  A list of edges.
+  """
+  edges: [ImageEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Image]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type ImageEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Image
 }

--- a/spec/integration/products_spec.rb
+++ b/spec/integration/products_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Products" do
   include_examples 'query is successful', :products do
     let(:product_nodes) { subject.data.products.nodes }
     let(:master_variant_nodes) { product_nodes.map(&:masterVariant) }
+    let(:master_variant_images_nodes) { master_variant_nodes.map(&:images) }
     let(:option_type_nodes) { product_nodes.map { |product_node| product_node.optionTypes.nodes }.flatten }
     let(:option_value_nodes) { option_type_nodes.map { |option_type| option_type.optionValues.nodes }.flatten }
     let(:product_properties_nodes) { product_nodes.map { |product_node| product_node.productProperties.nodes }.flatten }
@@ -28,6 +29,8 @@ RSpec.describe "Products" do
     it { expect(product_nodes).to be_present }
 
     it { expect(master_variant_nodes).to be_present }
+
+    it { expect(master_variant_images_nodes).to be_present }
 
     it { expect(option_type_nodes).to be_present }
 

--- a/spec/lib/solidus_graphql_api/queries/variant/images_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/variant/images_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Queries::Variant::ImagesQuery do
+  let(:variant) { create(:variant) }
+
+  let!(:images) { create_list(:image, 2, viewable: variant ) }
+
+  it { expect(described_class.new(variant: variant).call.sync).to eq(images) }
+end

--- a/spec/lib/solidus_graphql_api/types/variant_spec.rb
+++ b/spec/lib/solidus_graphql_api/types/variant_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe SolidusGraphqlApi::Types::Variant do
     it { expect(query_object).to receive(:call) }
   end
 
+  describe '#images' do
+    before do
+      allow(SolidusGraphqlApi::Queries::Variant::ImagesQuery).to receive(:new).and_return(query_object)
+    end
+
+    after { subject.images }
+
+    it { expect(SolidusGraphqlApi::Queries::Variant::ImagesQuery).to receive(:new).with(variant: variant) }
+
+    it { expect(query_object).to receive(:call) }
+  end
+
   describe '#option_values' do
     before do
       allow(SolidusGraphqlApi::Queries::Variant::OptionValuesQuery).to receive(:new).and_return(query_object)


### PR DESCRIPTION
 It adds the images connection field to the Variant Type and uses the `SolidusGraphqlApi::Queries::Variant::ImagesQuery` query object with batch loader to retrieve the images.