### PR TITLE
Update ruby image on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
 jobs:
   verify-schema-updated:
     docker:
-      - image: circleci/ruby:2.5.0-node
+      - image: circleci/ruby:2.5.6-node
         environment:
           BUNDLE_PATH: vendor/bundle
     steps:
@@ -53,7 +53,7 @@ jobs:
 
   schema-breaking-change-detection:
     docker:
-      - image: circleci/ruby:2.5.0-node
+      - image: circleci/ruby:2.5.6-node
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Update the ruby image:
from: circleci/ruby:2.5.0-node
to: circleci/ruby:2.5.6-node

To align the configuration with the ruby version used in the `solidusio/extensions` orb.
For more information:
https://github.com/solidusio/circleci-orbs-extensions/commit/42a30abeadd7f60c294bd964d50f0c539842ff34#diff-e7ad19500a51f86882a1e250e92cb28d