### PR TITLE
Add addresses field to user type

### DIFF
--- a/lib/solidus_graphql_api/types/user.rb
+++ b/lib/solidus_graphql_api/types/user.rb
@@ -5,11 +5,15 @@ module SolidusGraphqlApi
     class User < Base::RelayNode
       description 'User.'
 
+      field :addresses, Types::Address.connection_type, null: false
+      field :bill_address, Types::Address, null: true
       field :created_at, GraphQL::Types::ISO8601DateTime, null: true
       field :current_sign_in_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :default_address, Types::Address, null: true
       field :email, String, null: false
       field :last_sign_in_at, GraphQL::Types::ISO8601DateTime, null: true
       field :login, String, null: true
+      field :ship_address, Types::Address, null: true
       field :sign_in_count, Integer, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
     end

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,60 @@
 """
+Address.
+"""
+type Address implements Node {
+  address1: String
+  address2: String
+  alternativePhone: String
+  city: String
+  company: String
+  country: Country
+  createdAt: ISO8601DateTime
+  firstname: String
+  id: ID!
+  lastname: String
+  phone: String
+  state: State
+  stateName: String
+  updatedAt: ISO8601DateTime
+  zipcode: String
+}
+
+"""
+The connection type for Address.
+"""
+type AddressConnection {
+  """
+  A list of edges.
+  """
+  edges: [AddressEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Address]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type AddressEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Address
+}
+
+"""
 Country.
 """
 type Country implements Node {
@@ -794,12 +850,36 @@ type TaxonomyEdge {
 User.
 """
 type User implements Node {
+  addresses(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): AddressConnection!
+  billAddress: Address
   createdAt: ISO8601DateTime
   currentSignInAt: ISO8601DateTime
+  defaultAddress: Address
   email: String!
   id: ID!
   lastSignInAt: ISO8601DateTime
   login: String
+  shipAddress: Address
   signInCount: Int!
   updatedAt: ISO8601DateTime
 }

--- a/spec/expected_schema.graphql
+++ b/spec/expected_schema.graphql
@@ -145,6 +145,61 @@ type PageInfo {
   startCursor: String
 }
 
+"""
+Address.
+"""
+type Address implements Node {
+  address1: String
+  address2: String
+  alternativePhone: String
+  city: String
+  company: String
+  country: Country
+  createdAt: ISO8601DateTime
+  firstname: String
+  id: ID!
+  lastname: String
+  phone: String
+  state: State
+  stateName: String
+  updatedAt: ISO8601DateTime
+  zipcode: String
+}
+
+"""
+The connection type for Address.
+"""
+type AddressConnection {
+  """
+  A list of edges.
+  """
+  edges: [AddressEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Address]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type AddressEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Address
+}
 
 """
 Country.
@@ -448,12 +503,36 @@ type TaxonomyEdge {
 User.
 """
 type User implements Node {
+  addresses(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): AddressConnection!
+  billAddress: Address
   createdAt: ISO8601DateTime
   currentSignInAt: ISO8601DateTime
+  defaultAddress: Address
   email: String!
   id: ID!
   lastSignInAt: ISO8601DateTime
   login: String
+  shipAddress: Address
   signInCount: Int!
   updatedAt: ISO8601DateTime
 }

--- a/spec/integration/current_user_spec.rb
+++ b/spec/integration/current_user_spec.rb
@@ -4,9 +4,18 @@ require 'spec_helper'
 
 RSpec.describe "Current User" do
   include_examples 'query is successful', :currentUser do
-    let(:user) { create(:user) }
+    let(:user) { create(:user_with_addresses) }
+    let(:address_nodes) { subject.data.currentUser.addresses.nodes }
+    let(:default_address) { subject.data.currentUser.defaultAddress }
+    let(:ship_address) { subject.data.currentUser.shipAddress }
+    let(:bill_address) { subject.data.currentUser.billAddress }
     let(:context) { Hash[current_user: user] }
 
     it { expect(subject.data.currentUser).to_not be_nil }
+
+    it { expect(address_nodes).to be_present }
+    it { expect(default_address).to be_present }
+    it { expect(ship_address).to be_present }
+    it { expect(bill_address).to be_present }
   end
 end

--- a/spec/queries/currentUser.gql
+++ b/spec/queries/currentUser.gql
@@ -1,11 +1,138 @@
 query {
   currentUser {
-    email
-    signInCount
+    addresses {
+      nodes {
+        address1
+        address2
+        alternativePhone
+        city
+        company
+        country {
+          isoName
+          iso
+          iso3
+          name
+          numcode
+          statesRequired
+          createdAt
+          updatedAt
+        }
+        createdAt
+        firstname
+        id
+        lastname
+        phone
+        state {
+          name
+          abbr
+          createdAt
+          updatedAt
+        }
+        stateName
+        updatedAt
+        zipcode
+      }
+    }
+    billAddress {
+      address1
+      address2
+      alternativePhone
+      city
+      company
+      country {
+        isoName
+        iso
+        iso3
+        name
+        numcode
+        statesRequired
+        createdAt
+        updatedAt
+      }
+      createdAt
+      firstname
+      id
+      lastname
+      phone
+      state {
+        name
+        abbr
+        createdAt
+        updatedAt
+      }
+      stateName
+      updatedAt
+      zipcode
+    }
+    createdAt
     currentSignInAt
+    defaultAddress {
+      address1
+      address2
+      alternativePhone
+      city
+      company
+      country {
+        isoName
+        iso
+        iso3
+        name
+        numcode
+        statesRequired
+        createdAt
+        updatedAt
+      }
+      createdAt
+      firstname
+      id
+      lastname
+      phone
+      state {
+        name
+        abbr
+        createdAt
+        updatedAt
+      }
+      stateName
+      updatedAt
+      zipcode
+    }
+    email
+    id
     lastSignInAt
     login
-    createdAt
+    shipAddress{
+      address1
+      address2
+      alternativePhone
+      city
+      company
+      country {
+        isoName
+        iso
+        iso3
+        name
+        numcode
+        statesRequired
+        createdAt
+        updatedAt
+      }
+      createdAt
+      firstname
+      id
+      lastname
+      phone
+      state {
+        name
+        abbr
+        createdAt
+        updatedAt
+      }
+      stateName
+      updatedAt
+      zipcode
+    }
+    signInCount
     updatedAt
   }
 }


### PR DESCRIPTION
Add the following `Types::Address` fields to the User Type:
- A generic `addresses` node:
  - default: `[]`
  - To find all of the addresses associated with a User Type:
     - `defaultAddress`
     - `shipAddress`
     - `billAddress`

