### PR TITLE
Remove object id from the batch loader key

### DIFF
--- a/lib/solidus_graphql_api/batch_loader.rb
+++ b/lib/solidus_graphql_api/batch_loader.rb
@@ -101,7 +101,7 @@ module SolidusGraphqlApi
     def default_options
       return @default_options if @default_options
 
-      key_components = [object.class, object.id, reflection.name, options.inspect]
+      key_components = [object.class, reflection.name, options.inspect]
       key = Digest::MD5.hexdigest(key_components.join)
 
       @default_options ||= { key: key }.freeze


### PR DESCRIPTION
Using also the object id makes the batch loader key unique for every query.
This is not what we want because we need the same key to batch load the queries with the same object class and relation name.