### PR TITLE
Add an Object to manage the schema context

### DIFF
--- a/app/controllers/spree/graphql_controller.rb
+++ b/app/controllers/spree/graphql_controller.rb
@@ -8,7 +8,7 @@ module Spree
       render json: SolidusGraphqlApi::Schema.execute(
         params[:query],
         variables: ensure_hash(params[:variables]),
-        context: { current_user: current_user },
+        context: SolidusGraphqlApi::Context.new(request: request).to_h,
         operation_name: params[:operationName]
       )
     rescue StandardError => e
@@ -42,16 +42,6 @@ module Spree
       logger.error error.backtrace.join("\n")
 
       render json: { error: { message: error.message, backtrace: error.backtrace }, data: {} }, status: 500
-    end
-
-    def current_user
-      @current_user ||= Spree.user_class.find_by(spree_api_key: bearer_token.to_s)
-    end
-
-    def bearer_token
-      pattern = /^Bearer /
-      header = request.headers["Authorization"]
-      header.gsub(pattern, '') if header.present? && header.match(pattern)
     end
   end
 end

--- a/lib/solidus_graphql_api/context.rb
+++ b/lib/solidus_graphql_api/context.rb
@@ -14,7 +14,8 @@ module SolidusGraphqlApi
 
     def to_h
       { current_user: current_user,
-        current_ability: current_ability }
+        current_ability: current_ability,
+        order_token: order_token }
     end
 
     def current_user
@@ -23,6 +24,10 @@ module SolidusGraphqlApi
 
     def current_ability
       @current_ability ||= Spree::Ability.new(current_user)
+    end
+
+    def order_token
+      @order_token ||= headers["X-Spree-Order-Token"]
     end
 
     private

--- a/lib/solidus_graphql_api/context.rb
+++ b/lib/solidus_graphql_api/context.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  class Context
+    AUTHORIZATION_HEADER = "Authorization"
+    TOKEN_PATTERN = /^Bearer (?<token>.*)/.freeze
+
+    attr_reader :request, :headers
+
+    def initialize(request:)
+      @request = request
+      @headers = request.headers
+    end
+
+    def to_h
+      { current_user: current_user }
+    end
+
+    def current_user
+      @current_user ||= Spree.user_class.find_by(spree_api_key: bearer_token)
+    end
+
+    private
+
+    def bearer_token
+      @bearer_token ||= headers[AUTHORIZATION_HEADER].to_s.match(TOKEN_PATTERN) do |match_data|
+        match_data[:token]
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/context.rb
+++ b/lib/solidus_graphql_api/context.rb
@@ -15,6 +15,7 @@ module SolidusGraphqlApi
     def to_h
       { current_user: current_user,
         current_ability: current_ability,
+        current_store: current_store,
         order_token: order_token }
     end
 
@@ -28,6 +29,10 @@ module SolidusGraphqlApi
 
     def order_token
       @order_token ||= headers["X-Spree-Order-Token"]
+    end
+
+    def current_store
+      @current_store ||= Spree::Config.current_store_selector_class.new(request).store
     end
 
     private

--- a/lib/solidus_graphql_api/context.rb
+++ b/lib/solidus_graphql_api/context.rb
@@ -13,11 +13,16 @@ module SolidusGraphqlApi
     end
 
     def to_h
-      { current_user: current_user }
+      { current_user: current_user,
+        current_ability: current_ability }
     end
 
     def current_user
       @current_user ||= Spree.user_class.find_by(spree_api_key: bearer_token)
+    end
+
+    def current_ability
+      @current_ability ||= Spree::Ability.new(current_user)
     end
 
     private

--- a/spec/lib/solidus_graphql_api/context_spec.rb
+++ b/spec/lib/solidus_graphql_api/context_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Context do
+  let(:schema_context) { described_class.new(request: request) }
+
+  let(:headers) do
+    headers_hash = {}
+    headers_hash['Authorization'] = "Bearer #{authorization_token}" if defined?(authorization_token) && authorization_token
+    headers_hash
+  end
+
+  let(:request) { ActionDispatch::TestRequest.create.tap { |request| request.headers.merge!(headers) } }
+
+  describe '#to_h' do
+    subject { schema_context.to_h }
+
+    let(:current_user) { Spree::User.new }
+
+    before do
+      allow(schema_context).to receive(:current_user).and_return(current_user)
+    end
+
+    it { is_expected.to be_an(Hash) }
+
+    it { is_expected.to have_key(:current_user) }
+    it { expect(subject[:current_user]).to eq current_user }
+  end
+
+  describe '#current_user' do
+    subject { schema_context.current_user }
+
+    context 'when headers do not contains the authorization token' do
+      it { is_expected.to be_nil }
+    end
+
+    context 'when headers contains the authorization token' do
+      let!(:user) { create(:user).tap(&:generate_spree_api_key!) }
+
+      context 'and the authorization token is invalid' do
+        let(:authorization_token) { 'wrongauthorizationtoken' }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'and the authorization token is valid' do
+        let(:authorization_token) { user.spree_api_key }
+
+        it { is_expected.to eq user }
+      end
+    end
+  end
+end

--- a/spec/lib/solidus_graphql_api/context_spec.rb
+++ b/spec/lib/solidus_graphql_api/context_spec.rb
@@ -17,15 +17,20 @@ RSpec.describe SolidusGraphqlApi::Context do
     subject { schema_context.to_h }
 
     let(:current_user) { Spree::User.new }
+    let(:current_ability) { Spree::Ability.new(nil) }
 
     before do
       allow(schema_context).to receive(:current_user).and_return(current_user)
+      allow(schema_context).to receive(:current_ability).and_return(current_ability)
     end
 
     it { is_expected.to be_an(Hash) }
 
     it { is_expected.to have_key(:current_user) }
     it { expect(subject[:current_user]).to eq current_user }
+
+    it { is_expected.to have_key(:current_ability) }
+    it { expect(subject[:current_ability]).to eq current_ability }
   end
 
   describe '#current_user' do
@@ -48,6 +53,35 @@ RSpec.describe SolidusGraphqlApi::Context do
         let(:authorization_token) { user.spree_api_key }
 
         it { is_expected.to eq user }
+      end
+    end
+  end
+
+  describe '#current_ability' do
+    subject { schema_context.current_ability }
+
+    after { subject }
+
+    context 'when headers do not contains the authorization token' do
+      it { is_expected.to be_a Spree::Ability }
+      it { expect(Spree::Ability).to receive(:new).with(nil) }
+    end
+
+    context 'when headers contains the authorization token' do
+      let!(:user) { create(:user).tap(&:generate_spree_api_key!) }
+
+      context 'and the authorization token is invalid' do
+        let(:authorization_token) { 'wrongauthorizationtoken' }
+
+        it { is_expected.to be_a Spree::Ability }
+        it { expect(Spree::Ability).to receive(:new).with(nil) }
+      end
+
+      context 'and the authorization token is valid' do
+        let(:authorization_token) { user.spree_api_key }
+
+        it { is_expected.to be_a Spree::Ability }
+        it { expect(Spree::Ability).to receive(:new).with(user) }
       end
     end
   end

--- a/spec/lib/solidus_graphql_api/context_spec.rb
+++ b/spec/lib/solidus_graphql_api/context_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe SolidusGraphqlApi::Context do
   let(:headers) do
     headers_hash = {}
     headers_hash['Authorization'] = "Bearer #{authorization_token}" if defined?(authorization_token) && authorization_token
+    headers_hash['X-Spree-Order-Token'] = order_token if defined?(order_token) && order_token
     headers_hash
   end
 
@@ -18,6 +19,7 @@ RSpec.describe SolidusGraphqlApi::Context do
 
     let(:current_user) { Spree::User.new }
     let(:current_ability) { Spree::Ability.new(nil) }
+    let(:order_token) { "order_token" }
 
     before do
       allow(schema_context).to receive(:current_user).and_return(current_user)
@@ -31,6 +33,9 @@ RSpec.describe SolidusGraphqlApi::Context do
 
     it { is_expected.to have_key(:current_ability) }
     it { expect(subject[:current_ability]).to eq current_ability }
+
+    it { is_expected.to have_key(:order_token) }
+    it { expect(subject[:order_token]).to eq order_token }
   end
 
   describe '#current_user' do
@@ -84,5 +89,13 @@ RSpec.describe SolidusGraphqlApi::Context do
         it { expect(Spree::Ability).to receive(:new).with(user) }
       end
     end
+  end
+
+  describe '#order_token' do
+    subject { schema_context.order_token }
+
+    let(:order_token) { "order_token" }
+
+    it { is_expected.to eq order_token }
   end
 end

--- a/spec/lib/solidus_graphql_api/context_spec.rb
+++ b/spec/lib/solidus_graphql_api/context_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe SolidusGraphqlApi::Context do
 
     let(:current_user) { Spree::User.new }
     let(:current_ability) { Spree::Ability.new(nil) }
+    let!(:default_store) { create(:store, default: true) }
     let(:order_token) { "order_token" }
 
     before do
@@ -33,6 +34,9 @@ RSpec.describe SolidusGraphqlApi::Context do
 
     it { is_expected.to have_key(:current_ability) }
     it { expect(subject[:current_ability]).to eq current_ability }
+
+    it { is_expected.to have_key(:current_store) }
+    it { expect(subject[:current_store]).to eq default_store }
 
     it { is_expected.to have_key(:order_token) }
     it { expect(subject[:order_token]).to eq order_token }
@@ -89,6 +93,14 @@ RSpec.describe SolidusGraphqlApi::Context do
         it { expect(Spree::Ability).to receive(:new).with(user) }
       end
     end
+  end
+
+  describe '#current_store' do
+    subject { schema_context.current_store }
+
+    let!(:default_store) { create(:store, default: true) }
+
+    it { is_expected.to eq default_store }
   end
 
   describe '#order_token' do

--- a/spec/requests/spree/graphql_controller_spec.rb
+++ b/spec/requests/spree/graphql_controller_spec.rb
@@ -3,40 +3,15 @@
 require 'spec_helper'
 
 RSpec.describe Spree::GraphqlController do
-  shared_examples 'passes the right user in the context' do
-    before do
-      user.generate_spree_api_key!
-    end
+  let(:context) { Hash[] }
 
-    after do
-      post '/', headers: headers
-    end
+  before { allow_any_instance_of(SolidusGraphqlApi::Context).to receive(:to_h).and_return(context) }
 
-    it 'passes the right user in the context' do
-      expect(SolidusGraphqlApi::Schema).to receive(:execute).with(
-        nil, hash_including(context: context)
-      )
-    end
-  end
+  after { post '/', headers: headers }
 
-  let(:user) { create(:user) }
-  let(:context) { Hash[current_user: nil] }
-  let(:headers) { Hash[] }
-
-  context 'when no token is present' do
-    include_examples 'passes the right user in the context'
-  end
-
-  context 'when token is invalid' do
-    let(:headers) { Hash["Authorization" => "Bearer INVALID"] }
-
-    include_examples 'passes the right user in the context'
-  end
-
-  context 'when token is valid' do
-    let(:context) { Hash[current_user: user] }
-    let(:headers) { Hash["Authorization" => "Bearer #{user.spree_api_key}"] }
-
-    include_examples 'passes the right user in the context'
+  it 'passes the right context to the schema' do
+    expect(SolidusGraphqlApi::Schema).to receive(:execute).with(
+      nil, hash_including(context: context)
+    )
   end
 end


### PR DESCRIPTION
Extract the generation of the schema context into an own class (`SolidusGraphqlApi::Context`) and add the `current_ability`, `current_store` and `order_token` to the context.