### PR TITLE
Add Store Type

### DIFF
--- a/lib/solidus_graphql_api/types/query.rb
+++ b/lib/solidus_graphql_api/types/query.rb
@@ -31,6 +31,10 @@ module SolidusGraphqlApi
             null: true,
             description: 'Current logged User.'
 
+      field :current_store, Types::Store,
+            null: true,
+            description: 'Current Store.'
+
       def countries
         Queries::CountriesQuery.new.call
       end
@@ -49,6 +53,10 @@ module SolidusGraphqlApi
 
       def current_user
         context[:current_user]
+      end
+
+      def current_store
+        context[:current_store]
       end
     end
   end

--- a/lib/solidus_graphql_api/types/store.rb
+++ b/lib/solidus_graphql_api/types/store.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class Store < Base::RelayNode
+      description 'Store.'
+
+      field :cart_tax_country_iso, String, null: true
+      field :code, String, null: true
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :default_currency, String, null: true
+      field :default, Boolean, null: false
+      field :mail_from_address, String, null: true
+      field :meta_description, String, null: true
+      field :meta_keywords, String, null: true
+      field :name, String, null: true
+      field :seo_title, String, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :url, String, null: true
+    end
+  end
+end

--- a/schema.graphql
+++ b/schema.graphql
@@ -580,6 +580,11 @@ type Query {
   ): CountryConnection!
 
   """
+  Current Store.
+  """
+  currentStore: Store
+
+  """
   Current logged User.
   """
   currentUser: User
@@ -704,6 +709,25 @@ type StateEdge {
   The item at the end of the edge.
   """
   node: State
+}
+
+"""
+Store.
+"""
+type Store implements Node {
+  cartTaxCountryIso: String
+  code: String
+  createdAt: ISO8601DateTime
+  default: Boolean!
+  defaultCurrency: String
+  id: ID!
+  mailFromAddress: String
+  metaDescription: String
+  metaKeywords: String
+  name: String
+  seoTitle: String
+  updatedAt: ISO8601DateTime
+  url: String
 }
 
 """

--- a/spec/integration/current_store_spec.rb
+++ b/spec/integration/current_store_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "Current Store" do
+  include_examples 'query is successful', :currentStore do
+    let(:store) { create(:store) }
+    let(:context) { Hash[current_store: store] }
+
+    it { expect(subject.data.currentStore).to_not be_nil }
+  end
+end

--- a/spec/queries/currentStore.gql
+++ b/spec/queries/currentStore.gql
@@ -1,0 +1,16 @@
+query {
+  currentStore {
+    cartTaxCountryIso
+    code
+    createdAt
+    defaultCurrency
+    default
+    mailFromAddress
+    metaDescription
+    metaKeywords
+    name
+    seoTitle
+    updatedAt
+    url
+  }
+}

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -25,6 +25,11 @@ type Query {
   ): CountryConnection!
 
   """
+  Current Store.
+  """
+  currentStore: Store
+
+  """
   Current logged User.
   """
   currentUser: User
@@ -535,6 +540,25 @@ type User implements Node {
   shipAddress: Address
   signInCount: Int!
   updatedAt: ISO8601DateTime
+}
+
+"""
+Store.
+"""
+type Store implements Node {
+  cartTaxCountryIso: String
+  code: String
+  createdAt: ISO8601DateTime
+  default: Boolean!
+  defaultCurrency: String
+  id: ID!
+  mailFromAddress: String
+  metaDescription: String
+  metaKeywords: String
+  name: String
+  seoTitle: String
+  updatedAt: ISO8601DateTime
+  url: String
 }
 
 """


### PR DESCRIPTION
Quick Info
---

| Issue | Schema updates | New type |
| -- | -- | -- |
| #39 | :+1: | :+1: |

- [x] Add `Types::Store`:
  - All static fields refer to [`spree_stores`](https://github.com/solidusio/solidus/blob/475d9db5d0291dd4aeddc58ec919988c336729bb/core/db/migrate/20160101010000_solidus_one_four.rb#L930-L942
) table;
  - For association, refer to [`Spree::Store`](https://github.com/solidusio/solidus/blob/40605681840bc4853c9a1cffaa8860c414c96c03/core/app/models/spree/store.rb#L12-L18) model.
- [x] Add `current_store` in the query root:
  - The `current_store` field returns the `context[:current_store]` in form of `Types::Store`.
    For more information about how the current_user is initialized in the context, refer to:
[`SolidusGraphqlApi::Context: current_store`](https://github.com/nebulab/solidus_graphql_api-1/blob/rainerd/store-type/lib/solidus_graphql_api/context.rb#L34-L36)

**Note**
In this moment, all `Spree::Store` associations:
- `payment_methods`
- `shipping_methods`
- `orders`

aren't necessary for the context where the gem is used.