### PR TITLE
Remove graphiql-rails gem

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/'
-  end
-
   post '/', to: 'graphql#execute'
 end

--- a/lib/solidus_graphql_api.rb
+++ b/lib/solidus_graphql_api.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'graphql'
-require 'graphiql/rails'
 require 'batch-loader'
 
 require 'solidus_core'

--- a/solidus_graphql_api.gemspec
+++ b/solidus_graphql_api.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'batch-loader', '~> 1.4.1'
-  s.add_dependency 'graphiql-rails', '~> 1.7.0'
   s.add_dependency 'graphql', '~> 1.9.7'
   s.add_dependency 'solidus_core', '>= 2.5'
 


### PR DESCRIPTION
A developer must be able to choose which tool use to integrate with the graph and we also have one less external dependency to maintain.