### PR TITLE
Use match_array instead of eq in the queries specs

### DIFF
--- a/spec/lib/solidus_graphql_api/queries/countries_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/countries_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::CountriesQuery do
 
   let!(:countries) { create_list(:country, 2) }
 
-  it { is_expected.to eq(countries) }
+  it { is_expected.to match_array(countries) }
 end

--- a/spec/lib/solidus_graphql_api/queries/country/states_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/country/states_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::Country::StatesQuery do
 
   let!(:states) { create_list(:state, 2, country: country) }
 
-  it { expect(described_class.new(country: country).call.sync).to eq(states) }
+  it { expect(described_class.new(country: country).call.sync).to match_array(states) }
 end

--- a/spec/lib/solidus_graphql_api/queries/option_type/option_values_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/option_type/option_values_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::OptionType::OptionValuesQuery do
 
   let!(:option_values) { create_list(:option_value, 2, option_type: option_type) }
 
-  it { expect(described_class.new(option_type: option_type).call.sync).to eq(option_values) }
+  it { expect(described_class.new(option_type: option_type).call.sync).to match_array(option_values) }
 end

--- a/spec/lib/solidus_graphql_api/queries/product/option_types_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/product/option_types_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::Product::OptionTypesQuery do
 
   let!(:option_types) { create_list(:option_type, 2, products: [product]) }
 
-  it { expect(described_class.new(product: product).call.sync).to eq(option_types) }
+  it { expect(described_class.new(product: product).call.sync).to match_array(option_types) }
 end

--- a/spec/lib/solidus_graphql_api/queries/product/product_properties_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/product/product_properties_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::Product::ProductPropertiesQuery do
 
   let!(:product_properties) { create_list(:product_property, 2, product: product) }
 
-  it { expect(described_class.new(product: product).call.sync).to eq(product_properties) }
+  it { expect(described_class.new(product: product).call.sync).to match_array(product_properties) }
 end

--- a/spec/lib/solidus_graphql_api/queries/product/variants_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/product/variants_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::Product::VariantsQuery do
 
   let!(:variants) { create_list(:variant, 2, product: product) }
 
-  it { expect(described_class.new(product: product).call.sync).to eq(variants) }
+  it { expect(described_class.new(product: product).call.sync).to match_array(variants) }
 end

--- a/spec/lib/solidus_graphql_api/queries/products_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/products_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::ProductsQuery do
 
   let!(:products) { create_list(:product, 2) }
 
-  it { is_expected.to eq(products) }
+  it { is_expected.to match_array(products) }
 end

--- a/spec/lib/solidus_graphql_api/queries/taxon/children_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/taxon/children_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::Taxon::ChildrenQuery do
 
   let!(:children) { create_list(:taxon, 2, parent: taxon) }
 
-  it { expect(described_class.new(taxon: taxon).call.sync).to eq(children) }
+  it { expect(described_class.new(taxon: taxon).call.sync).to match_array(children) }
 end

--- a/spec/lib/solidus_graphql_api/queries/taxonomies_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/taxonomies_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::TaxonomiesQuery do
 
   let!(:taxonomies) { create_list(:taxonomy, 2) }
 
-  it { is_expected.to eq(taxonomies) }
+  it { is_expected.to match_array(taxonomies) }
 end

--- a/spec/lib/solidus_graphql_api/queries/variant/images_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/variant/images_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::Variant::ImagesQuery do
 
   let!(:images) { create_list(:image, 2, viewable: variant ) }
 
-  it { expect(described_class.new(variant: variant).call.sync).to eq(images) }
+  it { expect(described_class.new(variant: variant).call.sync).to match_array(images) }
 end

--- a/spec/lib/solidus_graphql_api/queries/variant/option_values_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/variant/option_values_query_spec.rb
@@ -7,5 +7,5 @@ RSpec.describe SolidusGraphqlApi::Queries::Variant::OptionValuesQuery do
 
   let!(:option_values) { create_list(:option_value, 2, variants: [variant]) }
 
-  it { expect(described_class.new(variant: variant).call.sync).to eq(option_values) }
+  it { expect(described_class.new(variant: variant).call.sync).to match_array(option_values) }
 end

--- a/spec/lib/solidus_graphql_api/queries/variant/prices_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/variant/prices_query_spec.rb
@@ -9,5 +9,5 @@ RSpec.describe SolidusGraphqlApi::Queries::Variant::PricesQuery do
 
   let!(:variant_prices) { [variant.default_price] + prices }
 
-  it { expect(described_class.new(variant: variant).call.sync).to eq(variant_prices) }
+  it { expect(described_class.new(variant: variant).call.sync).to match_array(variant_prices) }
 end


### PR DESCRIPTION
We don't care about the order of the returning result, only its contents.