### PR TITLE
Add order type and orders connection

### DIFF
--- a/lib/solidus_graphql_api/queries/completed_orders_query.rb
+++ b/lib/solidus_graphql_api/queries/completed_orders_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Queries
+    class CompletedOrdersQuery
+      attr_reader :user
+
+      def initialize(user:)
+        @user = user
+      end
+
+      def call
+        return [] unless user
+
+        user.orders.complete.order :id
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/queries/order/billing_address_query.rb
+++ b/lib/solidus_graphql_api/queries/order/billing_address_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Queries
+    module Order
+      class BillingAddressQuery
+        attr_reader :order
+
+        def initialize(order:)
+          @order = order
+        end
+
+        def call
+          SolidusGraphqlApi::BatchLoader.for(order, :bill_address)
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/queries/order/shipping_address_query.rb
+++ b/lib/solidus_graphql_api/queries/order/shipping_address_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Queries
+    module Order
+      class ShippingAddressQuery
+        attr_reader :order
+
+        def initialize(order:)
+          @order = order
+        end
+
+        def call
+          SolidusGraphqlApi::BatchLoader.for(order, :ship_address)
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/order.rb
+++ b/lib/solidus_graphql_api/types/order.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class Order < Base::RelayNode
+      description 'Order.'
+
+      field :additional_tax_total, String, null: false
+      field :adjustment_total, String, null: false
+      field :approved_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :billing_address, Address, null: false
+      field :canceled_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :completed_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :confirmation_delivered, Boolean, null: false
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :currency, String, null: false
+      field :email, String, null: false
+      field :guest_token, String, null: true
+      field :included_tax_total, String, null: false
+      field :item_total, String, null: false
+      field :number, String, null: false
+      field :payment_state, String, null: false
+      field :payment_total, String, null: false
+      field :promo_total, String, null: false
+      field :shipment_state, String, null: false
+      field :shipment_total, String, null: false
+      field :shipping_address, Address, null: false
+      field :special_instructions, String, null: true
+      field :state, String, null: false
+      field :total, String, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+
+      def billing_address
+        Queries::Order::BillingAddressQuery.new(order: object).call
+      end
+
+      def shipping_address
+        Queries::Order::ShippingAddressQuery.new(order: object).call
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/query.rb
+++ b/lib/solidus_graphql_api/types/query.rb
@@ -13,6 +13,10 @@ module SolidusGraphqlApi
             null: false,
             description: 'Supported Countries.'
 
+      field :completed_orders, Order.connection_type,
+            null: false,
+            description: 'Customer Completed Orders.'
+
       field :products, Product.connection_type,
             null: false,
             description: 'Supported Products.'
@@ -37,6 +41,10 @@ module SolidusGraphqlApi
 
       def countries
         Queries::CountriesQuery.new.call
+      end
+
+      def completed_orders
+        Queries::CompletedOrdersQuery.new(user: context[:current_user]).call
       end
 
       def products

--- a/schema.graphql
+++ b/schema.graphql
@@ -353,6 +353,72 @@ type OptionValueEdge {
 }
 
 """
+Order.
+"""
+type Order implements Node {
+  additionalTaxTotal: String!
+  adjustmentTotal: String!
+  approvedAt: ISO8601DateTime
+  billingAddress: Address!
+  canceledAt: ISO8601DateTime
+  completedAt: ISO8601DateTime
+  confirmationDelivered: Boolean!
+  createdAt: ISO8601DateTime
+  currency: String!
+  email: String!
+  guestToken: String
+  id: ID!
+  includedTaxTotal: String!
+  itemTotal: String!
+  number: String!
+  paymentState: String!
+  paymentTotal: String!
+  promoTotal: String!
+  shipmentState: String!
+  shipmentTotal: String!
+  shippingAddress: Address!
+  specialInstructions: String
+  state: String!
+  total: String!
+  updatedAt: ISO8601DateTime
+}
+
+"""
+The connection type for Order.
+"""
+type OrderConnection {
+  """
+  A list of edges.
+  """
+  edges: [OrderEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Order]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type OrderEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Order
+}
+
+"""
 Information about pagination in a connection.
 """
 type PageInfo {
@@ -599,6 +665,31 @@ type Property implements Node {
 }
 
 type Query {
+  """
+  Customer Completed Orders.
+  """
+  completedOrders(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): OrderConnection!
+
   """
   Supported Countries.
   """

--- a/spec/integration/completed_orders_spec.rb
+++ b/spec/integration/completed_orders_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe_query :completed_orders do
+  connection_field :completed_orders, query: :completed_orders, freeze_date: true do
+    let(:current_user) { create :user, email: 'email1@example.com' }
+    let(:query_context) { { current_user: current_user } }
+
+    context 'when there are not any completed orders' do
+      it { expect(subject.dig(:data, :completedOrders, :nodes)).to eq [] }
+    end
+
+    context 'when there are some completed orders' do
+      let(:ship_address_1_country) { create :country, id: 1 }
+      let(:ship_address_1_state) { create :state, id: 1, country: ship_address_1_country }
+      let(:bill_address_1_country) { create :country, id: 2 }
+      let(:bill_address_1_state) { create :state, id: 2, country: bill_address_1_country }
+      let(:ship_address_2_country) { create :country, id: 3 }
+      let(:ship_address_2_state) { create :state, id: 3, country: ship_address_2_country }
+      let(:bill_address_2_country) { create :country, id: 4 }
+      let(:bill_address_2_state) { create :state, id: 4, country: bill_address_2_country }
+      let(:ship_address_1) do
+        create(
+          :address,
+          id: 1,
+          zipcode: '10001',
+          address1: 'A Different Road',
+          country: ship_address_1_country,
+          state: ship_address_1_state
+        )
+      end
+      let(:bill_address_1) do
+        create(
+          :address,
+          id: 2,
+          zipcode: '10002',
+          address1: 'PO Box 1337',
+          country: bill_address_1_country,
+          state: bill_address_1_state
+        )
+      end
+      let(:ship_address_2) do
+        create(
+          :address,
+          id: 3,
+          zipcode: '10003',
+          address1: 'A Different Road',
+          country: ship_address_2_country,
+          state: ship_address_2_state
+        )
+      end
+      let(:bill_address_2) do
+        create(
+          :address,
+          id: 4,
+          zipcode: '10004',
+          address1: 'PO Box 1337',
+          country: bill_address_2_country,
+          state: bill_address_2_state
+        )
+      end
+      let(:order_1) do
+        create(
+          :completed_order_with_pending_payment,
+          id: 1,
+          user: current_user,
+          guest_token: 'fake guest token 1',
+          number: 'fake order number 1',
+          ship_address: ship_address_1,
+          bill_address: bill_address_1
+        )
+      end
+      let(:order_2) do
+        create(
+          :completed_order_with_pending_payment,
+          id: 2,
+          user: current_user,
+          guest_token: 'fake guest token 2',
+          number: 'fake order number 2',
+          ship_address: ship_address_2,
+          bill_address: bill_address_2
+        )
+      end
+      let!(:completed_orders) { [order_1, order_2] }
+
+      it { is_expected.to match_response('completed_orders') }
+
+      connection_field :shipping_address, query: 'completed_orders/shipping_address' do
+        it { is_expected.to match_response('completed_orders/shipping_address') }
+      end
+
+      connection_field :billing_address, query: 'completed_orders/billing_address' do
+        it { is_expected.to match_response('completed_orders/billing_address') }
+      end
+    end
+  end
+end

--- a/spec/lib/solidus_graphql_api/queries/completed_orders_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/completed_orders_query_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Queries::CompletedOrdersQuery do
+  subject { described_class.new(user: user).call }
+
+  let(:user) { create :user }
+  let!(:orders) { create_list(:completed_order_with_totals, 2, user: user) }
+
+  it { is_expected.to eq orders }
+end

--- a/spec/lib/solidus_graphql_api/queries/order/billing_address_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/order/billing_address_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Queries::Order::BillingAddressQuery do
+  let(:order) { create :order, bill_address: billing_address }
+
+  let(:billing_address) { create :bill_address }
+
+  it { expect(described_class.new(order: order).call.sync).to eq billing_address }
+end

--- a/spec/lib/solidus_graphql_api/queries/order/shipping_address_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/order/shipping_address_query_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Queries::Order::ShippingAddressQuery do
+  let(:order) { create :order, ship_address: shipping_address }
+
+  let(:shipping_address) { create :ship_address }
+
+  it { expect(described_class.new(order: order).call.sync).to eq shipping_address }
+end

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -1,5 +1,30 @@
 type Query {
   """
+  Customer Completed Orders.
+  """
+  completedOrders(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): OrderConnection!
+
+  """
   Supported Countries.
   """
   countries(
@@ -321,6 +346,37 @@ type CurrencyEdge {
   The item at the end of the edge.
   """
   node: Currency
+}
+
+"""
+Order.
+"""
+type Order implements Node {
+  additionalTaxTotal: String!
+  adjustmentTotal: String!
+  approvedAt: ISO8601DateTime
+  billingAddress: Address!
+  canceledAt: ISO8601DateTime
+  completedAt: ISO8601DateTime
+  confirmationDelivered: Boolean!
+  createdAt: ISO8601DateTime
+  currency: String!
+  email: String!
+  guestToken: String
+  id: ID!
+  includedTaxTotal: String!
+  itemTotal: String!
+  number: String!
+  paymentState: String!
+  paymentTotal: String!
+  promoTotal: String!
+  shipmentState: String!
+  shipmentTotal: String!
+  shippingAddress: Address!
+  specialInstructions: String
+  state: String!
+  total: String!
+  updatedAt: ISO8601DateTime
 }
 
 """
@@ -1088,4 +1144,39 @@ type ImageEdge {
   The item at the end of the edge.
   """
   node: Image
+}
+
+"""
+The connection type for Order.
+"""
+type OrderConnection {
+  """
+  A list of edges.
+  """
+  edges: [OrderEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Order]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type OrderEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Order
 }

--- a/spec/support/queries/completed_orders.gql
+++ b/spec/support/queries/completed_orders.gql
@@ -1,0 +1,29 @@
+query {
+  completedOrders {
+    nodes {
+      id
+      additionalTaxTotal
+      adjustmentTotal
+      approvedAt
+      canceledAt
+      completedAt
+      confirmationDelivered
+      createdAt
+      currency
+      email
+      guestToken
+      includedTaxTotal
+      itemTotal
+      number
+      paymentState
+      paymentTotal
+      promoTotal
+      shipmentState
+      shipmentTotal
+      specialInstructions
+      state
+      total
+      updatedAt
+    }
+  }
+}

--- a/spec/support/queries/completed_orders/billing_address.gql
+++ b/spec/support/queries/completed_orders/billing_address.gql
@@ -1,0 +1,40 @@
+query {
+  completedOrders {
+    nodes {
+      id
+      billingAddress {
+        id
+        address1
+        address2
+        alternativePhone
+        city
+        company
+        country {
+          id
+          createdAt
+          iso
+          iso3
+          isoName
+          name
+          numcode
+          updatedAt
+        }
+        id
+        createdAt
+        firstname
+        lastname
+        phone
+        state {
+          id
+          abbr
+          name
+          createdAt
+          updatedAt
+        }
+        stateName
+        updatedAt
+        zipcode
+      }
+    }
+  }
+}

--- a/spec/support/queries/completed_orders/shipping_address.gql
+++ b/spec/support/queries/completed_orders/shipping_address.gql
@@ -1,0 +1,40 @@
+query {
+  completedOrders {
+    nodes {
+      id
+      shippingAddress {
+        id
+        address1
+        address2
+        alternativePhone
+        city
+        company
+        country {
+          id
+          createdAt
+          iso
+          iso3
+          isoName
+          name
+          numcode
+          updatedAt
+        }
+        id
+        createdAt
+        firstname
+        lastname
+        phone
+        state {
+          id
+          abbr
+          name
+          createdAt
+          updatedAt
+        }
+        stateName
+        updatedAt
+        zipcode
+      }
+    }
+  }
+}

--- a/spec/support/query_results/completed_orders.json.erb
+++ b/spec/support/query_results/completed_orders.json.erb
@@ -1,0 +1,58 @@
+{
+  "data": {
+    "completedOrders": {
+      "nodes": [
+        {
+          "id": 1,
+          "additionalTaxTotal": "0.0",
+          "adjustmentTotal": "0.0",
+          "approvedAt": null,
+          "canceledAt": null,
+          "completedAt": "2012-12-21T12:00:00Z",
+          "confirmationDelivered": false,
+          "createdAt": "2012-12-21T12:00:00Z",
+          "currency": "USD",
+          "email": "email1@example.com",
+          "guestToken": "fake guest token 1",
+          "includedTaxTotal": "0.0",
+          "itemTotal": "10.0",
+          "number": "fake order number 1",
+          "paymentState": "balance_due",
+          "paymentTotal": "0.0",
+          "promoTotal": "0.0",
+          "shipmentState": "pending",
+          "shipmentTotal": "100.0",
+          "specialInstructions": null,
+          "state": "complete",
+          "total": "110.0",
+          "updatedAt": "2012-12-21T12:00:00Z"
+        },
+        {
+          "id": 2,
+          "additionalTaxTotal": "0.0",
+          "adjustmentTotal": "0.0",
+          "approvedAt": null,
+          "canceledAt": null,
+          "completedAt": "2012-12-21T12:00:00Z",
+          "confirmationDelivered": false,
+          "createdAt": "2012-12-21T12:00:00Z",
+          "currency": "USD",
+          "email": "email1@example.com",
+          "guestToken": "fake guest token 2",
+          "includedTaxTotal": "0.0",
+          "itemTotal": "10.0",
+          "number": "fake order number 2",
+          "paymentState": "balance_due",
+          "paymentTotal": "0.0",
+          "promoTotal": "0.0",
+          "shipmentState": "pending",
+          "shipmentTotal": "100.0",
+          "specialInstructions": null,
+          "state": "complete",
+          "total": "110.0",
+          "updatedAt": "2012-12-21T12:00:00Z"
+        }
+      ]
+    }
+  }
+}

--- a/spec/support/query_results/completed_orders/billing_address.json.erb
+++ b/spec/support/query_results/completed_orders/billing_address.json.erb
@@ -1,0 +1,78 @@
+{
+  "data": {
+    "completedOrders": {
+      "nodes": [
+        {
+          "id": 1,
+          "billingAddress": {
+            "id": 2,
+            "address1": "PO Box 1337",
+            "address2": "Northwest",
+            "alternativePhone": "555-555-0199",
+            "city": "Herndon",
+            "company": "Company",
+            "country": {
+              "id": 2,
+              "createdAt": "2012-12-21T12:00:00Z",
+              "iso": "US",
+              "iso3": "USA",
+              "isoName": "UNITED STATES",
+              "name": "United States",
+              "numcode": 840,
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "createdAt": "2012-12-21T12:00:00Z",
+            "firstname": "John",
+            "lastname": null,
+            "phone": "555-555-0199",
+            "state": {
+              "id": 2,
+              "abbr": "AL",
+              "name": "Alabama",
+              "createdAt": "2012-12-21T12:00:00Z",
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "stateName": null,
+            "updatedAt": "2012-12-21T12:00:00Z",
+            "zipcode": "10002"
+          }
+        },
+        {
+          "id": 2,
+          "billingAddress": {
+            "id": 4,
+            "address1": "PO Box 1337",
+            "address2": "Northwest",
+            "alternativePhone": "555-555-0199",
+            "city": "Herndon",
+            "company": "Company",
+            "country": {
+              "id": 4,
+              "createdAt": "2012-12-21T12:00:00Z",
+              "iso": "US",
+              "iso3": "USA",
+              "isoName": "UNITED STATES",
+              "name": "United States",
+              "numcode": 840,
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "createdAt": "2012-12-21T12:00:00Z",
+            "firstname": "John",
+            "lastname": null,
+            "phone": "555-555-0199",
+            "state": {
+              "id": 4,
+              "abbr": "AL",
+              "name": "Alabama",
+              "createdAt": "2012-12-21T12:00:00Z",
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "stateName": null,
+            "updatedAt": "2012-12-21T12:00:00Z",
+            "zipcode": "10004"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/spec/support/query_results/completed_orders/shipping_address.json.erb
+++ b/spec/support/query_results/completed_orders/shipping_address.json.erb
@@ -1,0 +1,78 @@
+{
+  "data": {
+    "completedOrders": {
+      "nodes": [
+        {
+          "id": 1,
+          "shippingAddress": {
+            "id": 1,
+            "address1": "A Different Road",
+            "address2": "Northwest",
+            "alternativePhone": "555-555-0199",
+            "city": "Herndon",
+            "company": "Company",
+            "country": {
+              "id": 1,
+              "createdAt": "2012-12-21T12:00:00Z",
+              "iso": "US",
+              "iso3": "USA",
+              "isoName": "UNITED STATES",
+              "name": "United States",
+              "numcode": 840,
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "createdAt": "2012-12-21T12:00:00Z",
+            "firstname": "John",
+            "lastname": null,
+            "phone": "555-555-0199",
+            "state": {
+              "id": 1,
+              "abbr": "AL",
+              "name": "Alabama",
+              "createdAt": "2012-12-21T12:00:00Z",
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "stateName": null,
+            "updatedAt": "2012-12-21T12:00:00Z",
+            "zipcode": "10001"
+          }
+        },
+        {
+          "id": 2,
+          "shippingAddress": {
+            "id": 3,
+            "address1": "A Different Road",
+            "address2": "Northwest",
+            "alternativePhone": "555-555-0199",
+            "city": "Herndon",
+            "company": "Company",
+            "country": {
+              "id": 3,
+              "createdAt": "2012-12-21T12:00:00Z",
+              "iso": "US",
+              "iso3": "USA",
+              "isoName": "UNITED STATES",
+              "name": "United States",
+              "numcode": 840,
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "createdAt": "2012-12-21T12:00:00Z",
+            "firstname": "John",
+            "lastname": null,
+            "phone": "555-555-0199",
+            "state": {
+              "id": 3,
+              "abbr": "AL",
+              "name": "Alabama",
+              "createdAt": "2012-12-21T12:00:00Z",
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "stateName": null,
+            "updatedAt": "2012-12-21T12:00:00Z",
+            "zipcode": "10003"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/spec/support/shared_examples/query_is_successful.rb
+++ b/spec/support/shared_examples/query_is_successful.rb
@@ -7,4 +7,6 @@ RSpec.shared_examples 'query is successful' do |query|
   let(:variables) { Hash[] }
 
   it { expect{ subject }.to_not raise_error }
+
+  it { expect(subject[:errors]).to be_nil }
 end


### PR DESCRIPTION
Closes #45. It adds the `Order` type, based on `Spree::Order`, and the `completedOrders` query, which returns the completed orders associated to the current user.