### PR TITLE
Allow developers to set a local .Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ nbproject
 pkg
 spec/dummy
 tmp
+.Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,8 @@ when 'postgresql'
   gem 'pg', '~> 0.21'
 end
 
+# Add your own local gems
+local_gemfile = File.expand_path('.Gemfile', __dir__)
+instance_eval File.read local_gemfile if File.exist? local_gemfile
+
 gemspec


### PR DESCRIPTION
So that gems like `graphiql-rails` are not required for regular development but can be used without bloating the `Gemfile` contents.