### PR TITLE
Add Currency Type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           command: gem install graphql-schema_comparator
       - run:
           name: Schema Breaking Change detection
-          command: rm Gemfile && schema_comparator verify "`git show master:schema.graphql`" schema.graphql
+          command: rm Gemfile && schema_comparator verify "`git show origin/master:schema.graphql`" schema.graphql
 
 workflows:
   "Run specs on supported Solidus versions":

--- a/lib/solidus_graphql_api/types/currency.rb
+++ b/lib/solidus_graphql_api/types/currency.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class Currency < Base::RelayNode
+      description 'Currency.'
+
+      field :html_entity, String, null: false
+      field :iso_code, String, null: false
+      field :name, String, null: false
+      field :symbol, String, null: false
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/price.rb
+++ b/lib/solidus_graphql_api/types/price.rb
@@ -8,14 +8,13 @@ module SolidusGraphqlApi
       field :amount, String, null: false
       field :country_iso, String, null: true
       field :created_at, GraphQL::Types::ISO8601DateTime, null: true
-      field :currency, String, null: false
-      field :currency_symbol, String, null: false
+      field :currency, Currency, null: false
       field :display_amount, String, null: false
       field :display_country, String, null: false
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
 
-      def currency_symbol
-        object.display_amount.currency.symbol
+      def currency
+        object.display_amount.currency
       end
     end
   end

--- a/lib/solidus_graphql_api/types/store.rb
+++ b/lib/solidus_graphql_api/types/store.rb
@@ -8,6 +8,7 @@ module SolidusGraphqlApi
       field :cart_tax_country_iso, String, null: true
       field :code, String, null: true
       field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :currencies, Currency.connection_type, null: false
       field :default_currency, String, null: true
       field :default, Boolean, null: false
       field :mail_from_address, String, null: true
@@ -17,6 +18,10 @@ module SolidusGraphqlApi
       field :seo_title, String, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
       field :url, String, null: true
+
+      def currencies
+        Spree::Config.available_currencies
+      end
     end
   end
 end

--- a/schema.graphql
+++ b/schema.graphql
@@ -126,6 +126,52 @@ type CountryEdge {
 }
 
 """
+Currency.
+"""
+type Currency implements Node {
+  htmlEntity: String!
+  id: ID!
+  isoCode: String!
+  name: String!
+  symbol: String!
+}
+
+"""
+The connection type for Currency.
+"""
+type CurrencyConnection {
+  """
+  A list of edges.
+  """
+  edges: [CurrencyEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Currency]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type CurrencyEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Currency
+}
+
+"""
 An ISO 8601-encoded datetime
 """
 scalar ISO8601DateTime
@@ -338,8 +384,7 @@ type Price implements Node {
   amount: String!
   countryIso: String
   createdAt: ISO8601DateTime
-  currency: String!
-  currencySymbol: String!
+  currency: Currency!
   displayAmount: String!
   displayCountry: String!
   id: ID!
@@ -718,6 +763,27 @@ type Store implements Node {
   cartTaxCountryIso: String
   code: String
   createdAt: ISO8601DateTime
+  currencies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): CurrencyConnection!
   default: Boolean!
   defaultCurrency: String
   id: ID!

--- a/spec/integration/current_store_spec.rb
+++ b/spec/integration/current_store_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 RSpec.describe_query :currentStore, query: :current_store, freeze_date: true do
   let!(:store) { create(:store, :with_defaults) }
 
+  before { Spree::Config.available_currencies = ::Money::Currency.first(2) }
+
   let(:query_context) { Hash[current_store: store] }
 
   field :currentStore do

--- a/spec/integration/products_spec.rb
+++ b/spec/integration/products_spec.rb
@@ -13,8 +13,10 @@ RSpec.describe "Products" do
     let(:product_properties_property_nodes) { product_properties_nodes.map { |node| node[:property] } }
     let(:variant_nodes) { product_nodes.map { |node| node.dig(:variants, :nodes) }.flatten }
     let(:variant_default_price_nodes) { variant_nodes.map { |node| node[:defaultPrice] } }
+    let(:default_price_currency_nodes) { variant_default_price_nodes.map { |node| node[:currency] } }
     let(:variant_option_value_nodes) { variant_nodes.map { |node| node.dig(:optionValues, :nodes) }.flatten }
     let(:variant_price_nodes) { variant_nodes.map { |variant_node| variant_node.dig(:prices, :nodes) }.flatten }
+    let(:price_currency_nodes) { variant_price_nodes.map { |node| node[:currency] } }
 
     let(:product) { create(:product_with_option_types) }
 
@@ -44,8 +46,12 @@ RSpec.describe "Products" do
 
     it { expect(variant_default_price_nodes).to be_present }
 
+    it { expect(default_price_currency_nodes).to be_present }
+
     it { expect(variant_option_value_nodes).to be_present }
 
     it { expect(variant_price_nodes).to be_present }
+
+    it { expect(price_currency_nodes).to be_present }
   end
 end

--- a/spec/lib/solidus_graphql_api/types/price_spec.rb
+++ b/spec/lib/solidus_graphql_api/types/price_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require 'spec_helper'
-
-RSpec.describe SolidusGraphqlApi::Types::Price do
-  it { expect(described_class.method_defined?(:currency_symbol)).to be_truthy }
-end

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -278,6 +278,63 @@ type CountryEdge {
 }
 
 """
+Currency.
+"""
+type Currency implements Node {
+  htmlEntity: String!
+  id: ID!
+  isoCode: String!
+  name: String!
+  symbol: String!
+}
+
+"""
+The connection type for Currency.
+"""
+type CurrencyConnection {
+  """
+  A list of edges.
+  """
+  edges: [CurrencyEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [Currency]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type CurrencyEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: Currency
+}
+
+"""
+Currency.
+"""
+type Currency implements Node {
+  htmlEntity: String!
+  id: ID!
+  isoCode: String!
+  name: String!
+  symbol: String!
+}
+
+"""
 State.
 """
 type State implements Node {
@@ -549,6 +606,27 @@ type Store implements Node {
   cartTaxCountryIso: String
   code: String
   createdAt: ISO8601DateTime
+  currencies(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): CurrencyConnection!
   default: Boolean!
   defaultCurrency: String
   id: ID!
@@ -674,8 +752,7 @@ type Price implements Node {
  amount: String!
  countryIso: String
  createdAt: ISO8601DateTime
- currency: String!
- currencySymbol: String!
+ currency: Currency!
  displayAmount: String!
  displayCountry: String!
  id: ID!

--- a/spec/support/queries/current_store.gql
+++ b/spec/support/queries/current_store.gql
@@ -3,6 +3,14 @@ query {
     cartTaxCountryIso
     code
     createdAt
+    currencies {
+      nodes {
+        htmlEntity
+        isoCode
+        name
+        symbol
+      }
+    }
     default
     defaultCurrency
     mailFromAddress

--- a/spec/support/queries/products.gql
+++ b/spec/support/queries/products.gql
@@ -54,8 +54,12 @@ query {
             amount
             countryIso
             createdAt
-            currency
-            currencySymbol
+            currency {
+              htmlEntity
+              isoCode
+              name
+              symbol
+            }
             displayAmount
             displayCountry
             id
@@ -81,8 +85,12 @@ query {
               amount
               countryIso
               createdAt
-              currency
-              currencySymbol
+              currency {
+                htmlEntity
+                isoCode
+                name
+                symbol
+              }
               displayAmount
               displayCountry
               id

--- a/spec/support/query_results/current_store.json.erb
+++ b/spec/support/query_results/current_store.json.erb
@@ -4,6 +4,22 @@
       "cartTaxCountryIso": "US",
       "code": "solidus",
       "createdAt": "2012-12-21T12:00:00Z",
+      "currencies": {
+        "nodes": [
+          {
+            "htmlEntity": "$",
+            "isoCode": "USD",
+            "name": "United States Dollar",
+            "symbol": "$"
+          },
+          {
+            "htmlEntity": "&#x20AC;",
+            "isoCode": "EUR",
+            "name": "Euro",
+            "symbol": "€"
+          }
+        ]
+      },
       "default": true,
       "defaultCurrency": "USD",
       "mailFromAddress": "spree@example.org",


### PR DESCRIPTION
Quick Info
---

| Issue | Schema updates | New type |
| -- | -- | -- |
| #53 | :+1: | :+1: |

- [x] Add `Types::Currency`:
- Add `currencies` in the `Types::Store`
   - [x] Implementation
   - [x] specs
- Add `currency` in the `Types::Price`
   - [x] Implementation
   - [x] delete `price_spec.rb`
- [x] Fix the `breaking change detection` in CircleCI

Note
---
[`schema-breaking-change-detection`](https://circleci.com/gh/nebulab/solidus_graphql_api-1/1404?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) fails because is necessary to deprecate the modified fields here: [`SolidusGraphqlApi::Types::PriceType`](https://github.com/nebulab/solidus_graphql_api-1/pull/62/files#diff-f22605e393de246522adef9a4984fc34L11-R11)
For the moment, since the gem hasn't yet been officially released, we don't bother to deprecate the fields.