### PR TITLE
Improve snapshot specs error messages

### DIFF
--- a/spec/integration/countries_spec.rb
+++ b/spec/integration/countries_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe_query :countries do
   connection_field :countries, query: :countries, freeze_date: true do
     context 'when countries does not exists' do
-      it { expect(subject.data.countries.nodes).to be_empty }
+      it { expect(subject.dig(:data, :countries, :nodes)).to eq [] }
     end
 
     context 'when countries exists' do

--- a/spec/integration/current_user_spec.rb
+++ b/spec/integration/current_user_spec.rb
@@ -5,13 +5,13 @@ require 'spec_helper'
 RSpec.describe "Current User" do
   include_examples 'query is successful', :currentUser do
     let(:user) { create(:user_with_addresses) }
-    let(:address_nodes) { subject.data.currentUser.addresses.nodes }
-    let(:default_address) { subject.data.currentUser.defaultAddress }
-    let(:ship_address) { subject.data.currentUser.shipAddress }
-    let(:bill_address) { subject.data.currentUser.billAddress }
+    let(:address_nodes) { subject.dig(:data, :currentUser, :addresses, :nodes) }
+    let(:default_address) { subject.dig(:data, :currentUser, :defaultAddress) }
+    let(:ship_address) { subject.dig(:data, :currentUser, :shipAddress) }
+    let(:bill_address) { subject.dig(:data, :currentUser, :billAddress) }
     let(:context) { Hash[current_user: user] }
 
-    it { expect(subject.data.currentUser).to_not be_nil }
+    it { expect(subject.dig(:data, :currentUser)).to be_present }
 
     it { expect(address_nodes).to be_present }
     it { expect(default_address).to be_present }

--- a/spec/integration/products_spec.rb
+++ b/spec/integration/products_spec.rb
@@ -4,17 +4,17 @@ require 'spec_helper'
 
 RSpec.describe "Products" do
   include_examples 'query is successful', :products do
-    let(:product_nodes) { subject.data.products.nodes }
-    let(:master_variant_nodes) { product_nodes.map(&:masterVariant) }
-    let(:master_variant_images_nodes) { master_variant_nodes.map(&:images) }
-    let(:option_type_nodes) { product_nodes.map { |product_node| product_node.optionTypes.nodes }.flatten }
-    let(:option_value_nodes) { option_type_nodes.map { |option_type| option_type.optionValues.nodes }.flatten }
-    let(:product_properties_nodes) { product_nodes.map { |product_node| product_node.productProperties.nodes }.flatten }
-    let(:product_properties_property_nodes) { product_properties_nodes.map(&:property) }
-    let(:variant_nodes) { product_nodes.map { |product_node| product_node.variants.nodes }.flatten }
-    let(:variant_default_price_nodes) { variant_nodes.map(&:defaultPrice) }
-    let(:variant_option_value_nodes) { variant_nodes.map { |variant_node| variant_node.optionValues.nodes }.flatten }
-    let(:variant_price_nodes) { variant_nodes.map { |variant_node| variant_node.prices.nodes }.flatten }
+    let(:product_nodes) { subject.dig(:data, :products, :nodes) }
+    let(:master_variant_nodes) { product_nodes.map { |node| node[:masterVariant] } }
+    let(:master_variant_images_nodes) { master_variant_nodes.map { |node| node[:images] } }
+    let(:option_type_nodes) { product_nodes.map { |node| node.dig(:optionTypes, :nodes) }.flatten }
+    let(:option_value_nodes) { option_type_nodes.map { |node| node.dig(:optionValues, :nodes) }.flatten }
+    let(:product_properties_nodes) { product_nodes.map { |node| node.dig(:productProperties, :nodes) }.flatten }
+    let(:product_properties_property_nodes) { product_properties_nodes.map { |node| node[:property] } }
+    let(:variant_nodes) { product_nodes.map { |node| node.dig(:variants, :nodes) }.flatten }
+    let(:variant_default_price_nodes) { variant_nodes.map { |node| node[:defaultPrice] } }
+    let(:variant_option_value_nodes) { variant_nodes.map { |node| node.dig(:optionValues, :nodes) }.flatten }
+    let(:variant_price_nodes) { variant_nodes.map { |variant_node| variant_node.dig(:prices, :nodes) }.flatten }
 
     let(:product) { create(:product_with_option_types) }
 

--- a/spec/integration/taxonomies_spec.rb
+++ b/spec/integration/taxonomies_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe_query :taxonomies do
   connection_field :taxonomies, query: :taxonomies, freeze_date: true do
     context 'when taxonomies does not exists' do
-      it { expect(subject.data.taxonomies.nodes).to be_empty }
+      it { expect(subject.dig(:data, :taxonomies, :nodes)).to eq [] }
     end
 
     context 'when taxonomies exists' do

--- a/spec/support/helpers/graphql.rb
+++ b/spec/support/helpers/graphql.rb
@@ -2,7 +2,7 @@
 
 module Helpers
   module Graphql
-    def execute_query(query, variables: {}, context: {}, decode_ids: true, object_class: OpenStruct)
+    def execute_query(query, variables: {}, context: {}, decode_ids: true, object_class: Hash)
       query_result = SolidusGraphqlApi::Schema.execute(
         File.read("spec/support/queries/#{query}.gql"),
         variables: variables,
@@ -11,7 +11,7 @@ module Helpers
 
       query_result = decode_field_ids(query_result.to_h) if decode_ids
 
-      JSON.parse(query_result.to_json, object_class: object_class)
+      JSON.parse(query_result.to_json, object_class: object_class, symbolize_names: true)
     end
 
     def decode_field_ids(field)

--- a/spec/support/matchers/graphql.rb
+++ b/spec/support/matchers/graphql.rb
@@ -6,12 +6,17 @@ module Matchers
 
     matcher :match_response do |query_result_file|
       match do |actual|
-        template = File.read("spec/support/query_results/#{query_result_file}.json.erb")
+        query_result_path = "spec/support/query_results/#{query_result_file}.json.erb"
+        template = File.read(query_result_path)
         json_result = ERB.new(template).result_with_hash(@variables || {})
 
-        @expected = JSON.parse(json_result, object_class: @object_class || OpenStruct)
+        @expected = JSON.parse(json_result, object_class: @object_class || Hash, symbolize_names: true)
 
-        actual == @expected
+        # Lets the failure message have a nice diff
+        @expected = JSON.pretty_generate @expected
+        @actual = JSON.pretty_generate actual
+
+        @actual == @expected
       end
 
       chain :with_args do |variables|
@@ -22,11 +27,8 @@ module Matchers
         @object_class = object_class
       end
 
-      failure_message_when_negated do |actual|
-        "expected that #{actual} would not be equal of #{expected}"
-      end
-
       diffable
+
       attr_reader :expected
     end
   end


### PR DESCRIPTION
It lets the snapshot specs print a usable diff in case of not matching response.

**BEFORE**

![Schermata del 2020-01-17 10-09-24](https://user-images.githubusercontent.com/283320/72600089-3f74c300-3913-11ea-840a-4e6a783fe151.png)

**AFTER**

![Schermata del 2020-01-17 10-05-33](https://user-images.githubusercontent.com/283320/72600099-46033a80-3913-11ea-9ef2-b4b63868cd28.png)
