### PR TITLE
Remove duplicated declaration in expected schema

### DIFF
--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -324,17 +324,6 @@ type CurrencyEdge {
 }
 
 """
-Currency.
-"""
-type Currency implements Node {
-  htmlEntity: String!
-  id: ID!
-  isoCode: String!
-  name: String!
-  symbol: String!
-}
-
-"""
 State.
 """
 type State implements Node {


### PR DESCRIPTION
The expected schema includes a double GraphQL type declaration for `Currency`. This commit removes one of them.