### PR TITLE
Improve product by slug spec

### DIFF
--- a/spec/integration/queries/product_by_slug_spec.rb
+++ b/spec/integration/queries/product_by_slug_spec.rb
@@ -2,8 +2,41 @@
 
 require 'spec_helper'
 
-RSpec.describe "ProductBySlug" do
-  include_examples 'query is successful', :product_by_slug do
-    let!(:product) { create(:product, slug: 'slug') }
+RSpec.describe_query :product_by_slug, query: :product_by_slug, freeze_date: true do
+  let!(:product) { create(:product, id: 1, name: 'Product', slug: 'slug', sku: 'SKU') }
+
+  let!(:option_type) { create(:option_type, id: 1, name: 'foo-size') }
+  let!(:option_value) { create(:option_value, id: 1, name: 'Size', option_type: option_type) }
+  let!(:product_option_type) { create(:product_option_type, id: 1, product: product, option_type: option_type) }
+
+  let!(:product_property) { create(:product_property, id: 1, product: product) }
+
+  let!(:first_variant) { create(:base_variant, product: product) }
+  let!(:second_variant) { create(:base_variant, product: product) }
+
+  before do
+    product.master.update!(option_values: [option_value])
+  end
+
+  field :productBySlug do
+    context "when the slug doesn't exist" do
+      let(:query_variables) { { slug: 'non-existent-slug' } }
+
+      it { expect(subject.dig(:data, :productBySlug)).to be_nil }
+    end
+
+    context 'when the slug exists' do
+      let(:query_variables) { { slug: 'slug' } }
+
+      let(:args) do
+        {
+          product: product,
+          first_variant: first_variant,
+          second_variant: second_variant
+        }
+      end
+
+      it { is_expected.to match_response(:product_by_slug).with_args(args) }
+    end
   end
 end

--- a/spec/support/graphql/queries/product_by_slug.gql
+++ b/spec/support/graphql/queries/product_by_slug.gql
@@ -1,5 +1,106 @@
-query {
-  productBySlug(slug: "slug") {
+query ($slug: String!) {
+  productBySlug(slug: $slug) {
+    createdAt
+    description
     id
+    masterVariant {
+      createdAt
+      defaultPrice {
+        amount
+        countryIso
+        createdAt
+        currency {
+          htmlEntity
+          isoCode
+          name
+          symbol
+        }
+        displayAmount
+        displayCountry
+        id
+        updatedAt
+      }
+      depth
+      height
+      id
+      isMaster
+      optionValues {
+        nodes {
+          createdAt
+          id
+          name
+          position
+          presentation
+          updatedAt
+        }
+      }
+      position
+      prices {
+        nodes {
+          amount
+          countryIso
+          createdAt
+          currency {
+            htmlEntity
+            isoCode
+            name
+            symbol
+          }
+          displayAmount
+          displayCountry
+          id
+          updatedAt
+        }
+      }
+      sku
+      updatedAt
+      weight
+      width
+    }
+    metaDescription
+    metaKeywords
+    metaTitle
+    name
+    optionTypes {
+      nodes {
+        createdAt
+        id
+        name
+        optionValues {
+          nodes {
+            createdAt
+            id
+            name
+            position
+            presentation
+            updatedAt
+          }
+        }
+        position
+        presentation
+        updatedAt
+      }
+    }
+    productProperties {
+      nodes {
+        createdAt
+        position
+        property {
+          createdAt
+          name
+          presentation
+          updatedAt
+        }
+        updatedAt
+        value
+      }
+    }
+    slug
+    updatedAt
+    variants {
+      nodes {
+        id
+      }
+    }
   }
 }

--- a/spec/support/graphql/responses/product_by_slug.json.erb
+++ b/spec/support/graphql/responses/product_by_slug.json.erb
@@ -1,0 +1,123 @@
+{
+  "data": {
+    "productBySlug": {
+      "createdAt": "2012-12-21T12:00:00Z",
+      "description": "As seen on TV!",
+      "id": 1,
+      "masterVariant": {
+        "createdAt": "2012-12-21T12:00:00Z",
+        "defaultPrice": {
+          "amount": "19.99",
+          "countryIso": null,
+          "createdAt": "2012-12-21T12:00:00Z",
+          "currency": {
+            "htmlEntity": "$",
+            "isoCode": "USD",
+            "name": "United States Dollar",
+            "symbol": "$"
+          },
+          "displayAmount": "$19.99",
+          "displayCountry": "Any Country",
+          "id": <%= product.master.default_price.id %>,
+          "updatedAt": "2012-12-21T12:00:00Z"
+        },
+        "depth": null,
+        "height": null,
+        "id": <%= product.master.id %>,
+        "isMaster": true,
+        "optionValues": {
+          "nodes": [
+            {
+              "createdAt": "2012-12-21T12:00:00Z",
+              "id": 1,
+              "name": "Size",
+              "position": "1",
+              "presentation": "S",
+              "updatedAt": "2012-12-21T12:00:00Z"
+            }
+          ]
+        },
+        "position": 1,
+        "prices": {
+          "nodes": [
+            {
+              "amount": "19.99",
+              "countryIso": null,
+              "createdAt": "2012-12-21T12:00:00Z",
+              "currency": {
+                "htmlEntity": "$",
+                "isoCode": "USD",
+                "name": "United States Dollar",
+                "symbol": "$"
+              },
+              "displayAmount": "$19.99",
+              "displayCountry": "Any Country",
+              "id": <%= product.master.prices.first.id %>,
+              "updatedAt": "2012-12-21T12:00:00Z"
+            }
+          ]
+        },
+        "sku": "SKU",
+        "updatedAt": "2012-12-21T12:00:00Z",
+        "weight": "0.0",
+        "width": null
+      },
+      "metaDescription": null,
+      "metaKeywords": null,
+      "metaTitle": null,
+      "name": "Product",
+      "optionTypes": {
+        "nodes": [
+          {
+            "createdAt": "2012-12-21T12:00:00Z",
+            "id": 1,
+            "name": "foo-size",
+            "optionValues": {
+              "nodes": [
+                {
+                  "createdAt": "2012-12-21T12:00:00Z",
+                  "id": 1,
+                  "name": "Size",
+                  "position": "1",
+                  "presentation": "S",
+                  "updatedAt": "2012-12-21T12:00:00Z"
+                }
+              ]
+            },
+            "position": 1,
+            "presentation": "Size",
+            "updatedAt": "2012-12-21T12:00:00Z"
+          }
+        ]
+      },
+      "productProperties": {
+        "nodes": [
+          {
+            "createdAt": "2012-12-21T12:00:00Z",
+            "position": 1,
+            "property": {
+              "createdAt": "2012-12-21T12:00:00Z",
+              "name": "baseball_cap_color",
+              "presentation": "cap color",
+              "updatedAt": "2012-12-21T12:00:00Z"
+            },
+            "updatedAt": "2012-12-21T12:00:00Z",
+            "value": null
+          }
+        ]
+      },
+      "slug": "slug",
+      "updatedAt": "2012-12-21T12:00:00Z",
+      "variants": {
+        "nodes": [
+          {
+            "id": <%= first_variant.id %>
+          },
+          {
+            "id": <%= second_variant.id %>
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Uses the `describe_query` and `connection_field` example groups to set the subject query and to freeze the time, and the `match_response` custom matcher to compare the query with the result.