### PR TITLE
Add LineItem type and order.lineItems field

### DIFF
--- a/lib/solidus_graphql_api/queries/line_item/variant_query.rb
+++ b/lib/solidus_graphql_api/queries/line_item/variant_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Queries
+    module LineItem
+      class VariantQuery
+        attr_reader :line_item
+
+        def initialize(line_item:)
+          @line_item = line_item
+        end
+
+        def call
+          SolidusGraphqlApi::BatchLoader.for(line_item, :variant)
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/queries/order/line_items_query.rb
+++ b/lib/solidus_graphql_api/queries/order/line_items_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Queries
+    module Order
+      class LineItemsQuery
+        attr_reader :order
+
+        def initialize(order:)
+          @order = order
+        end
+
+        def call
+          SolidusGraphqlApi::BatchLoader.for(order, :line_items)
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/line_item.rb
+++ b/lib/solidus_graphql_api/types/line_item.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module SolidusGraphqlApi
+  module Types
+    class LineItem < Base::RelayNode
+      description 'Line item.'
+
+      field :additional_tax_total, Float, null: false
+      field :adjustment_total, Float, null: false
+      field :amount, Float, null: false
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :currency, String, null: false
+      field :has_sufficient_stock, Boolean, null: false, method: :sufficient_stock?
+      field :included_tax_total, Float, null: false
+      field :price, Float, null: false
+      field :promo_total, Float, null: false
+      field :quantity, Integer, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :variant, Variant, null: false
+
+      def variant
+        Queries::LineItem::VariantQuery.new(line_item: object).call
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql_api/types/order.rb
+++ b/lib/solidus_graphql_api/types/order.rb
@@ -18,6 +18,7 @@ module SolidusGraphqlApi
       field :guest_token, String, null: true
       field :included_tax_total, String, null: false
       field :item_total, String, null: false
+      field :line_items, LineItem.connection_type, null: false
       field :number, String, null: false
       field :payment_state, String, null: false
       field :payment_total, String, null: false
@@ -32,6 +33,10 @@ module SolidusGraphqlApi
 
       def billing_address
         Queries::Order::BillingAddressQuery.new(order: object).call
+      end
+
+      def line_items
+        Queries::Order::LineItemsQuery.new(order: object).call
       end
 
       def shipping_address

--- a/schema.graphql
+++ b/schema.graphql
@@ -228,6 +228,60 @@ type ImageEdge {
 }
 
 """
+Line item.
+"""
+type LineItem implements Node {
+  additionalTaxTotal: Float!
+  adjustmentTotal: Float!
+  amount: Float!
+  createdAt: ISO8601DateTime
+  currency: String!
+  hasSufficientStock: Boolean!
+  id: ID!
+  includedTaxTotal: Float!
+  price: Float!
+  promoTotal: Float!
+  quantity: Int!
+  updatedAt: ISO8601DateTime
+  variant: Variant!
+}
+
+"""
+The connection type for LineItem.
+"""
+type LineItemConnection {
+  """
+  A list of edges.
+  """
+  edges: [LineItemEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [LineItem]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type LineItemEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: LineItem
+}
+
+"""
 An object with an ID.
 """
 interface Node {
@@ -370,6 +424,27 @@ type Order implements Node {
   id: ID!
   includedTaxTotal: String!
   itemTotal: String!
+  lineItems(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): LineItemConnection!
   number: String!
   paymentState: String!
   paymentTotal: String!

--- a/spec/lib/solidus_graphql_api/queries/line_item/variant_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/line_item/variant_query_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Queries::LineItem::VariantQuery do
+  let(:line_item) { create(:line_item) }
+
+  it { expect(described_class.new(line_item: line_item).call.sync).to eq(line_item.variant) }
+end

--- a/spec/lib/solidus_graphql_api/queries/order/line_items_query_spec.rb
+++ b/spec/lib/solidus_graphql_api/queries/order/line_items_query_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusGraphqlApi::Queries::Order::LineItemsQuery do
+  let(:order) { create :order_with_line_items, line_items_count: 2 }
+
+  it { expect(described_class.new(order: order).call.sync).to eq order.line_items }
+end

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -141,6 +141,60 @@ An ISO 8601-encoded datetime
 scalar ISO8601DateTime
 
 """
+Line item.
+"""
+type LineItem implements Node {
+  additionalTaxTotal: Float!
+  adjustmentTotal: Float!
+  amount: Float!
+  createdAt: ISO8601DateTime
+  currency: String!
+  hasSufficientStock: Boolean!
+  id: ID!
+  includedTaxTotal: Float!
+  price: Float!
+  promoTotal: Float!
+  quantity: Int!
+  updatedAt: ISO8601DateTime
+  variant: Variant!
+}
+
+"""
+The connection type for LineItem.
+"""
+type LineItemConnection {
+  """
+  A list of edges.
+  """
+  edges: [LineItemEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [LineItem]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type LineItemEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: LineItem
+}
+
+"""
 An object with an ID.
 """
 interface Node {
@@ -377,6 +431,27 @@ type Order implements Node {
   state: String!
   total: String!
   updatedAt: ISO8601DateTime
+  lineItems(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): LineItemConnection!
 }
 
 """

--- a/spec/support/graphql/queries/completed_orders/line_items.gql
+++ b/spec/support/graphql/queries/completed_orders/line_items.gql
@@ -1,0 +1,23 @@
+query {
+  completedOrders {
+    nodes {
+      id
+      lineItems {
+        nodes {
+          id
+          additionalTaxTotal
+          adjustmentTotal
+          amount
+          createdAt
+          currency
+          hasSufficientStock
+          includedTaxTotal
+          price
+          promoTotal
+          quantity
+          updatedAt
+        }
+      }
+    }
+  }
+}

--- a/spec/support/graphql/responses/completed_orders/line_items.json.erb
+++ b/spec/support/graphql/responses/completed_orders/line_items.json.erb
@@ -1,0 +1,43 @@
+{
+  "data": {
+    "completedOrders": {
+      "nodes": [
+        {
+          "id": 1,
+          "lineItems": {
+            "nodes": [
+              {
+                "id": <%= line_items[0].id %>,
+                "additionalTaxTotal": 0.0,
+                "adjustmentTotal": 0.0,
+                "amount": 10.0,
+                "createdAt": "2012-12-21T12:00:00Z",
+                "currency": "USD",
+                "hasSufficientStock": true,
+                "includedTaxTotal": 0.0,
+                "price": 10.0,
+                "promoTotal": 0.0,
+                "quantity": 1,
+                "updatedAt": "2012-12-21T12:00:00Z"
+              },
+              {
+                "id": <%= line_items[1].id %>,
+                "additionalTaxTotal": 0.0,
+                "adjustmentTotal": 0.0,
+                "amount": 10.0,
+                "createdAt": "2012-12-21T12:00:00Z",
+                "currency": "USD",
+                "hasSufficientStock": true,
+                "includedTaxTotal": 0.0,
+                "price": 10.0,
+                "promoTotal": 0.0,
+                "quantity": 1,
+                "updatedAt": "2012-12-21T12:00:00Z"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
It adds the `LineItem` type, based on `Spree::LineItem`, and the `order.lineItems` connection field, which returns the line items associated to the queried order.