### PR TITLE
Current order

### DIFF
--- a/lib/solidus_graphql_api/types/query.rb
+++ b/lib/solidus_graphql_api/types/query.rb
@@ -39,6 +39,10 @@ module SolidusGraphqlApi
             null: true,
             description: 'Current Store.'
 
+      field :current_order, Types::Order,
+            null: true,
+            description: 'Current Order.'
+
       def countries
         Queries::CountriesQuery.new.call
       end
@@ -65,6 +69,10 @@ module SolidusGraphqlApi
 
       def current_store
         context[:current_store]
+      end
+
+      def current_order
+        context[:current_order]
       end
     end
   end

--- a/schema.graphql
+++ b/schema.graphql
@@ -795,6 +795,11 @@ type Query {
   ): CountryConnection!
 
   """
+  Current Order.
+  """
+  currentOrder: Order
+
+  """
   Current Store.
   """
   currentStore: Store

--- a/spec/integration/queries/current_order_spec.rb
+++ b/spec/integration/queries/current_order_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe_query :currentOrder, query: :current_order, freeze_date: true do
+  let!(:order) { create :order, id: 1, number: 'fake number' }
+
+  let(:query_context) { { current_order: order } }
+
+  field :currentOrder do
+    it { is_expected.to match_response(:current_order) }
+  end
+end

--- a/spec/support/expected_schema.graphql
+++ b/spec/support/expected_schema.graphql
@@ -795,6 +795,11 @@ type Query {
   ): CountryConnection!
 
   """
+  Current Order.
+  """
+  currentOrder: Order
+
+  """
   Current Store.
   """
   currentStore: Store

--- a/spec/support/graphql/queries/current_order.gql
+++ b/spec/support/graphql/queries/current_order.gql
@@ -1,0 +1,6 @@
+query {
+  currentOrder {
+    id
+    number
+  }
+}

--- a/spec/support/graphql/responses/current_order.json.erb
+++ b/spec/support/graphql/responses/current_order.json.erb
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "currentOrder": {
+      "id": 1,
+      "number": "fake number"
+    }
+  }
+}


### PR DESCRIPTION
It adds `current_order` to the context, which is responsible for fetching the last incomplete order from the current user or, if not found, the current order by the guest token. It returns `nil` if none of both are  found.


It also adds the `currentOrder` query, which is responsible for fetching the current order form the context and returning it.


