### PR TITLE
Fix user sign-in bug

### DIFF
--- a/lib/solidus_graphql_api/services/user/sign_in.rb
+++ b/lib/solidus_graphql_api/services/user/sign_in.rb
@@ -7,9 +7,11 @@ module SolidusGraphqlApi
         attr_reader :user
 
         def call(email:, password:)
-          @user = Spree.user_class.find_for_authentication(email: email)
+          user = Spree.user_class.find_for_authentication(email: email)
 
-          @user.present? && @user.valid_password?(password)
+          user.present? && user.valid_password?(password).tap do |valid_password|
+            @user = valid_password ? user : nil
+          end
         end
       end
     end

--- a/spec/integration/mutations/sign_in_spec.rb
+++ b/spec/integration/mutations/sign_in_spec.rb
@@ -6,26 +6,40 @@ RSpec.describe_mutation :sign_in, mutation: :sign_in do
   let(:email) { "john@example.com" }
   let(:password) { "secret" }
 
-  let(:mutation_variables) {
-    {
-      input: {
-        email: email,
-        password: password
-      }
-    }
-  }
+  let!(:user) { create(:user, email: 'john@example.com', password: 'secret') }
+
+  let(:mutation_variables) { Hash[input: { email: email, password: password }] }
 
   context "when given valid credentials" do
-    let!(:user) { create(:user, email: email, password: password) }
-
     it { expect(subject[:data][:signIn][:user][:email]).to eq(email) }
 
     it { expect(subject[:data][:signIn][:errors]).to be_empty }
   end
 
   context "when given invalid credentials" do
-    it { expect(subject[:data][:signIn][:user]).to be_nil }
+    context 'with wrong email' do
+      let(:email) { 'wrongemail@example.com' }
 
-    it { expect(subject[:data][:signIn][:errors]).to eq ["Invalid email or password."] }
+      it { expect(subject[:data][:signIn][:user]).to be_nil }
+
+      it { expect(subject[:data][:signIn][:errors]).to eq ["Invalid email or password."] }
+    end
+
+    context 'with wrong password' do
+      let(:password) { 'wrongpassword' }
+
+      it { expect(subject[:data][:signIn][:user]).to be_nil }
+
+      it { expect(subject[:data][:signIn][:errors]).to eq ["Invalid email or password."] }
+    end
+
+    context 'with wrong email and password' do
+      let(:email) { 'wrongemail@example.com' }
+      let(:password) { 'wrongpassword' }
+
+      it { expect(subject[:data][:signIn][:user]).to be_nil }
+
+      it { expect(subject[:data][:signIn][:errors]).to eq ["Invalid email or password."] }
+    end
   end
 end

--- a/spec/lib/solidus_graphql_api/services/user/sign_in_spec.rb
+++ b/spec/lib/solidus_graphql_api/services/user/sign_in_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe SolidusGraphqlApi::Services::User::SignIn do
   let(:email) { "john@example.com" }
   let(:password) { "secret" }
 
+  let!(:user) { create(:user, email: "john@example.com", password: "secret") }
+
   subject(:instance) { described_class.new }
 
   describe "#call" do
     subject { instance.call(email: email, password: password) }
 
     context "when given valid credentials" do
-      let!(:user) { create(:user, email: email, password: password) }
-
       it { is_expected.to be true }
 
       context 'instance' do
@@ -24,12 +24,41 @@ RSpec.describe SolidusGraphqlApi::Services::User::SignIn do
     end
 
     context "when given invalid credentials" do
-      it { is_expected.to be false }
+      context 'with wrong email' do
+        let(:email) { 'wrongemail@example.com' }
 
-      context 'instance' do
-        before { subject }
+        it { is_expected.to be false }
 
-        it { expect(instance.user).to be_nil }
+        context 'instance' do
+          before { subject }
+
+          it { expect(instance.user).to be_nil }
+        end
+      end
+
+      context 'with wrong password' do
+        let(:password) { 'wrongpassword' }
+
+        it { is_expected.to be false }
+
+        context 'instance' do
+          before { subject }
+
+          it { expect(instance.user).to be_nil }
+        end
+      end
+
+      context 'with wrong email and password' do
+        let(:email) { 'wrongemail@example.com' }
+        let(:password) { 'wrongpassword' }
+
+        it { is_expected.to be false }
+
+        context 'instance' do
+          before { subject }
+
+          it { expect(instance.user).to be_nil }
+        end
       end
     end
   end


### PR DESCRIPTION
Before this commit, the service object "User::SignIn" returned the user
even if the password was incorrect.